### PR TITLE
fix(integrations): add missing Microsoft.Extensions.Http package reference

### DIFF
--- a/BanterBotSports.Integrations/BanterBotSports.Integrations.csproj
+++ b/BanterBotSports.Integrations/BanterBotSports.Integrations.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Telegram.Bot" Version="22.9.5.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

- `IHttpClientFactory` was used in `ApiFootballClient.cs`, `TelegramBotService.cs`, and `WhisperService.cs` without the corresponding NuGet package being referenced in the project file.
- Adding `Microsoft.Extensions.Http 10.0.5` to `BanterBotSports.Integrations.csproj` resolves the build blocker.

## Root Cause

The package was implicitly available through transitive dependencies in some configurations but was never explicitly declared, causing the build to fail in clean/CI environments.