### PR TITLE
fix(banterai): fix SystemMessage constructor and FuentePrediccion enum reference

### DIFF
--- a/BanterBotSports.BanterAI/BanterEngine.cs
+++ b/BanterBotSports.BanterAI/BanterEngine.cs
@@ -39,6 +39,9 @@ public class BanterEngine : IBanterEngine
 
     public async Task<string> GenerateBanterAsync(ParticipanteStats stats, Torneo torneo)
     {
+        ArgumentNullException.ThrowIfNull(stats);
+        ArgumentNullException.ThrowIfNull(torneo);
+
         try
         {
             var userMessage = BuildUserMessage(stats, torneo);
@@ -49,7 +52,7 @@ public class BanterEngine : IBanterEngine
                 MaxTokens = 300,
                 System = new List<SystemMessage>
                 {
-                    new SystemMessage { Text = SystemPrompt }
+                    new SystemMessage(SystemPrompt)
                 },
                 Messages = new List<Message>
                 {

--- a/BanterBotSports.BanterAI/PrediccionExtractionService.cs
+++ b/BanterBotSports.BanterAI/PrediccionExtractionService.cs
@@ -66,6 +66,9 @@ public class PrediccionExtractionService : IPrediccionExtractionService
 
     public async Task<ExtractionResult> ExtractAsync(string text, IReadOnlyList<PartidoDto> partidos)
     {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(partidos);
+
         try
         {
             var userMessage = BuildUserMessage(text, partidos);
@@ -74,7 +77,7 @@ public class PrediccionExtractionService : IPrediccionExtractionService
             {
                 Model = ModelId,
                 MaxTokens = 1024,
-                System = [new SystemMessage { Text = SystemPrompt }],
+                System = [new SystemMessage(SystemPrompt)],
                 Messages =
                 [
                     new Message
@@ -141,7 +144,7 @@ public class PrediccionExtractionService : IPrediccionExtractionService
                     PartidoId: p.MatchId,
                     GolesEquipo1: p.LocalGoals,
                     GolesEquipo2: p.VisitanteGoals,
-                    Fuente: FuentePrediccion.Texto
+                    Fuente: FuentePrediccion.Telegram
                 ))
                 .ToList();
 


### PR DESCRIPTION
## Summary
- Replace `SystemMessage { Text = ... }` object initializer with `SystemMessage(...)` positional constructor (Anthropic.SDK 5.10.0 API change) in `BanterEngine.cs` and `PrediccionExtractionService.cs`
- Replace non-existent `FuentePrediccion.Texto` with `FuentePrediccion.Telegram` in `PrediccionExtractionService.cs`
- Add missing `ArgumentNullException.ThrowIfNull()` guard clauses on `GenerateBanterAsync` and `ExtractAsync` public methods (required by GGA)

## Test plan
- [ ] Verify `dotnet build` succeeds with no CS7036 or CS0117 errors
- [ ] Run existing BanterAI unit tests