### PR TITLE
fix: resolve Web Program.cs namespace and Tests UnitOfWork constructor mismatches

### DIFF
--- a/BanterBotSports.Tests/Integration/PrediccionServiceIntegrationTests.cs
+++ b/BanterBotSports.Tests/Integration/PrediccionServiceIntegrationTests.cs
@@ -40,7 +40,7 @@ public class PrediccionServiceIntegrationTests : IAsyncLifetime
 
         var prediccionRepo = new PrediccionRepository(_context);
         var jornadaRepo = new JornadaRepository(_context);
-        _prediccionService = new PrediccionService(prediccionRepo, jornadaRepo, _context);
+        _prediccionService = new PrediccionService(prediccionRepo, jornadaRepo, new UnitOfWork(_context));
     }
 
     public async Task DisposeAsync()

--- a/BanterBotSports.Tests/Integration/TelegramWebhookIntegrationTests.cs
+++ b/BanterBotSports.Tests/Integration/TelegramWebhookIntegrationTests.cs
@@ -49,7 +49,7 @@ public class TelegramWebhookIntegrationTests : IAsyncLifetime
 
         var prediccionRepo = new PrediccionRepository(_context);
         var jornadaRepo = new JornadaRepository(_context);
-        _prediccionService = new PrediccionService(prediccionRepo, jornadaRepo, _context);
+        _prediccionService = new PrediccionService(prediccionRepo, jornadaRepo, new UnitOfWork(_context));
     }
 
     public async Task DisposeAsync()

--- a/BanterBotSports.Web/Program.cs
+++ b/BanterBotSports.Web/Program.cs
@@ -1,5 +1,6 @@
 using BanterBotSports.BanterAI;
 using BanterBotSports.BL.Services;
+using BanterBotSports.BL.Services.Hosted;
 using BanterBotSports.BL.Services.Interfaces;
 using BanterBotSports.DAL;
 using BanterBotSports.DAL.Repositories;


### PR DESCRIPTION
## Summary
- Add missing `using BanterBotSports.BL.Services.Hosted` in `Program.cs` — fixes CS0246 (`DeadlineEnforcerService` not found)
- Replace `_context` with `new UnitOfWork(_context)` in `PrediccionServiceIntegrationTests` — fixes CS1503 (constructor now expects `IUnitOfWork`)
- Replace `_context` with `new UnitOfWork(_context)` in `TelegramWebhookIntegrationTests` — fixes CS1503 (same constructor change)

## Test plan
- [ ] `dotnet build` passes with 0 errors
- [ ] All integration tests compile and run against TestContainers PostgreSQL