### PR TITLE
fix(tests): update confidence values to match 0.95 threshold

### DIFF
--- a/BanterBotSports.Tests/Unit/PrediccionExtractionServiceTests.cs
+++ b/BanterBotSports.Tests/Unit/PrediccionExtractionServiceTests.cs
@@ -172,7 +172,7 @@ public class PrediccionExtractionServiceTests
               "predictions": [
                 { "matchId": 99, "localGoals": 2, "visitanteGoals": 1 }
               ],
-              "confidence": 0.9
+              "confidence": 0.96
             }
             """;
         var sut = BuildSut();
@@ -194,7 +194,7 @@ public class PrediccionExtractionServiceTests
               "predictions": [
                 { "matchId": 5, "localGoals": 0, "visitanteGoals": 2 }
               ],
-              "confidence": 0.88
+              "confidence": 0.96
             }
             Hope this helps!
             """;


### PR DESCRIPTION
## Summary
- Update `confidence` value in `ParseResponse_ValidJsonWithMatchIdNotInList_FiltersOut` from `0.9` to `0.96`
- Update `confidence` value in `ParseResponse_JsonWithExtraTextAround_ExtractsJsonBlock` from `0.88` to `0.96`

Both tests were using confidence values below the `MinConfidence` threshold of `0.95` raised in commit `73be97d`, causing them to fail.

## Test plan
- [ ] Both unit tests should now pass with confidence values above the 0.95 threshold