### PR TITLE
feat: player payment confirmation and auto-baja on jornada open

### DIFF
--- a/BanterBotSports.BL/Services/Interfaces/ITorneoService.cs
+++ b/BanterBotSports.BL/Services/Interfaces/ITorneoService.cs
@@ -43,4 +43,23 @@ public interface ITorneoService
     /// Requires torneo.Participantes to be loaded.
     /// </summary>
     Task<IReadOnlyList<RankingParticipante>> BuildRankingAsync(Torneo torneo);
+
+    /// <summary>
+    /// Confirms payment for a participant. Only the organizer can call this.
+    /// Idempotent: if already paid, does nothing.
+    /// </summary>
+    Task ConfirmarPagoAsync(int torneoId, int participanteId, string organizadorId);
+
+    /// <summary>
+    /// Revokes payment for a participant. Only the organizer can call this.
+    /// Cannot revoke the organizer's own payment (Rol=Ambos).
+    /// </summary>
+    Task RevocarPagoAsync(int torneoId, int participanteId, string organizadorId);
+
+    /// <summary>
+    /// Removes all unpaid participants from the torneo and deletes their predictions.
+    /// The organizer (Rol=Ambos) is never removed.
+    /// Returns the number of participants removed.
+    /// </summary>
+    Task<int> DarDeBajaImpagosAsync(int torneoId);
 }

--- a/BanterBotSports.BL/Services/JornadaService.cs
+++ b/BanterBotSports.BL/Services/JornadaService.cs
@@ -18,6 +18,7 @@ public class JornadaService : IJornadaService
     private readonly IJornadaRepository _jornadaRepository;
     private readonly IPartidoRepository _partidoRepository;
     private readonly IParticipanteRepository _participanteRepository;
+    private readonly ITorneoService _torneoService;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<JornadaService> _logger;
 
@@ -37,18 +38,21 @@ public class JornadaService : IJornadaService
         IJornadaRepository jornadaRepository,
         IPartidoRepository partidoRepository,
         IParticipanteRepository participanteRepository,
+        ITorneoService torneoService,
         IUnitOfWork unitOfWork,
         ILogger<JornadaService> logger)
     {
         ArgumentNullException.ThrowIfNull(jornadaRepository);
         ArgumentNullException.ThrowIfNull(partidoRepository);
         ArgumentNullException.ThrowIfNull(participanteRepository);
+        ArgumentNullException.ThrowIfNull(torneoService);
         ArgumentNullException.ThrowIfNull(unitOfWork);
         ArgumentNullException.ThrowIfNull(logger);
 
         _jornadaRepository = jornadaRepository;
         _partidoRepository = partidoRepository;
         _participanteRepository = participanteRepository;
+        _torneoService = torneoService;
         _unitOfWork = unitOfWork;
         _logger = logger;
     }
@@ -71,6 +75,15 @@ public class JornadaService : IJornadaService
         {
             throw new InvalidOperationException(
                 $"La jornada {jornada.Numero} no puede abrirse desde el estado '{jornada.Estado}'.");
+        }
+
+        // Auto-baja: remove unpaid participants BEFORE opening predictions
+        var removidos = await _torneoService.DarDeBajaImpagosAsync(jornada.TorneoId);
+        if (removidos > 0)
+        {
+            _logger.LogInformation(
+                "Auto-baja: {Removidos} unpaid participant(s) removed from torneo {TorneoId} before opening jornada {JornadaId}.",
+                removidos, jornada.TorneoId, jornada.Id);
         }
 
         // Load partidos to set DeadlineUtc and validate that at least one exists

--- a/BanterBotSports.BL/Services/TorneoService.cs
+++ b/BanterBotSports.BL/Services/TorneoService.cs
@@ -134,6 +134,76 @@ public class TorneoService : ITorneoService
     }
 
     /// <inheritdoc />
+    public async Task ConfirmarPagoAsync(int torneoId, int participanteId, string organizadorId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(organizadorId);
+
+        var torneo = await _torneoRepository.GetByIdAsync(torneoId)
+            ?? throw new InvalidOperationException($"Torneo {torneoId} no encontrado.");
+
+        if (torneo.OrganizadorId != organizadorId)
+            throw new UnauthorizedAccessException("Solo el organizador puede confirmar pagos.");
+
+        var participante = await _participanteRepository.GetByIdAsync(participanteId)
+            ?? throw new InvalidOperationException($"Participante {participanteId} no encontrado.");
+
+        if (participante.TorneoId != torneoId)
+            throw new InvalidOperationException("El participante no pertenece a este torneo.");
+
+        if (participante.Pago)
+            return; // already paid — idempotent
+
+        participante.Pago = true;
+        await _participanteRepository.UpdateAsync(participante);
+        await _unitOfWork.SaveAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task RevocarPagoAsync(int torneoId, int participanteId, string organizadorId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(organizadorId);
+
+        var torneo = await _torneoRepository.GetByIdAsync(torneoId)
+            ?? throw new InvalidOperationException($"Torneo {torneoId} no encontrado.");
+
+        if (torneo.OrganizadorId != organizadorId)
+            throw new UnauthorizedAccessException("Solo el organizador puede revocar pagos.");
+
+        var participante = await _participanteRepository.GetByIdAsync(participanteId)
+            ?? throw new InvalidOperationException($"Participante {participanteId} no encontrado.");
+
+        if (participante.TorneoId != torneoId)
+            throw new InvalidOperationException("El participante no pertenece a este torneo.");
+
+        if (participante.Rol == RolParticipante.Ambos)
+            throw new InvalidOperationException("No se puede revocar el pago del organizador.");
+
+        participante.Pago = false;
+        await _participanteRepository.UpdateAsync(participante);
+        await _unitOfWork.SaveAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task<int> DarDeBajaImpagosAsync(int torneoId)
+    {
+        var participantes = await _participanteRepository.GetByTorneoIdAsync(torneoId);
+        var impagos = participantes
+            .Where(p => !p.Pago && p.Rol != RolParticipante.Ambos)
+            .ToList();
+
+        foreach (var impago in impagos)
+        {
+            await _prediccionRepository.DeleteByParticipanteIdAsync(impago.Id);
+            await _participanteRepository.DeleteAsync(impago);
+        }
+
+        if (impagos.Count > 0)
+            await _unitOfWork.SaveAsync();
+
+        return impagos.Count;
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<RankingParticipante>> BuildRankingAsync(Torneo torneo)
     {
         ArgumentNullException.ThrowIfNull(torneo);

--- a/BanterBotSports.DAL/Repositories/Interfaces/IPrediccionRepository.cs
+++ b/BanterBotSports.DAL/Repositories/Interfaces/IPrediccionRepository.cs
@@ -19,4 +19,10 @@ public interface IPrediccionRepository
     Task<IReadOnlyList<PrediccionJornada>> GetPrediccionesJornadaByJornadaAsync(int jornadaId);
     Task<PrediccionJornada> AddPrediccionJornadaAsync(PrediccionJornada prediccion);
     Task UpdatePrediccionJornadaAsync(PrediccionJornada prediccion);
+
+    /// <summary>
+    /// Deletes all PrediccionPartido and PrediccionJornada records for the given participant.
+    /// Used during auto-baja of unpaid players.
+    /// </summary>
+    Task DeleteByParticipanteIdAsync(int participanteId);
 }

--- a/BanterBotSports.DAL/Repositories/PrediccionRepository.cs
+++ b/BanterBotSports.DAL/Repositories/PrediccionRepository.cs
@@ -98,4 +98,17 @@ public class PrediccionRepository : IPrediccionRepository
         _context.PrediccionesJornada.Update(prediccion);
         return Task.CompletedTask;
     }
+
+    public async Task DeleteByParticipanteIdAsync(int participanteId)
+    {
+        var prediccionesPartido = await _context.PrediccionesPartido
+            .Where(pp => pp.ParticipanteId == participanteId)
+            .ToListAsync();
+        _context.PrediccionesPartido.RemoveRange(prediccionesPartido);
+
+        var prediccionesJornada = await _context.PrediccionesJornada
+            .Where(pj => pj.ParticipanteId == participanteId)
+            .ToListAsync();
+        _context.PrediccionesJornada.RemoveRange(prediccionesJornada);
+    }
 }

--- a/BanterBotSports.Tests/Integration/JornadaAbiertaNotifierIntegrationTests.cs
+++ b/BanterBotSports.Tests/Integration/JornadaAbiertaNotifierIntegrationTests.cs
@@ -1,4 +1,5 @@
 using BanterBotSports.BL.Services;
+using BanterBotSports.BL.Services.Interfaces;
 using BanterBotSports.DAL;
 using BanterBotSports.DAL.Repositories;
 using BanterBotSports.DAL.Repositories.Interfaces;
@@ -74,6 +75,7 @@ public class JornadaAbiertaNotifierIntegrationTests : IAsyncLifetime
             jornadaRepo,
             partidoRepo,
             participanteRepo,
+            new Mock<ITorneoService>().Object,
             uow,
             NullLogger<JornadaService>.Instance);
 

--- a/BanterBotSports.Tests/Integration/JornadaServiceIntegrationTests.cs
+++ b/BanterBotSports.Tests/Integration/JornadaServiceIntegrationTests.cs
@@ -1,4 +1,5 @@
 using BanterBotSports.BL.Services;
+using BanterBotSports.BL.Services.Interfaces;
 using BanterBotSports.DAL;
 using BanterBotSports.DAL.Repositories;
 using BanterBotSports.Entities;
@@ -6,6 +7,7 @@ using BanterBotSports.Entities.Enums;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Testcontainers.PostgreSql;
 
 namespace BanterBotSports.Tests.Integration;
@@ -49,6 +51,7 @@ public class JornadaServiceIntegrationTests : IAsyncLifetime
             jornadaRepo,
             partidoRepo,
             participanteRepo,
+            new Mock<ITorneoService>().Object,
             uow,
             NullLogger<JornadaService>.Instance);
     }

--- a/BanterBotSports.Tests/Unit/JornadaServiceAutoBajaTests.cs
+++ b/BanterBotSports.Tests/Unit/JornadaServiceAutoBajaTests.cs
@@ -1,0 +1,90 @@
+using BanterBotSports.BL.Services;
+using BanterBotSports.BL.Services.Interfaces;
+using BanterBotSports.DAL.Repositories.Interfaces;
+using BanterBotSports.Entities;
+using BanterBotSports.Entities.Enums;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BanterBotSports.Tests.Unit;
+
+/// <summary>
+/// Verifies that AbrirJornadaAsync calls DarDeBajaImpagosAsync
+/// before transitioning the jornada to Abierta.
+/// </summary>
+public class JornadaServiceAutoBajaTests
+{
+    private readonly Mock<IJornadaRepository> _jornadaRepo = new();
+    private readonly Mock<IPartidoRepository> _partidoRepo = new();
+    private readonly Mock<IParticipanteRepository> _participanteRepo = new();
+    private readonly Mock<ITorneoService> _torneoService = new();
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+
+    private JornadaService BuildSut() => new(
+        _jornadaRepo.Object,
+        _partidoRepo.Object,
+        _participanteRepo.Object,
+        _torneoService.Object,
+        _unitOfWork.Object,
+        NullLogger<JornadaService>.Instance);
+
+    [Fact]
+    public async Task AbrirJornada_CallsDarDeBajaImpagos_BeforeStateTransition()
+    {
+        // Arrange
+        var jornada = new Jornada { Id = 1, TorneoId = 10, Numero = 1, Estado = EstadoJornada.PendientePartidos };
+        var partido = new Partido
+        {
+            Id = 100, JornadaId = 1, Equipo1 = "A", Equipo2 = "B",
+            KickOffUtc = DateTime.UtcNow.AddDays(1)
+        };
+
+        _jornadaRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(jornada);
+        _partidoRepo.Setup(r => r.GetByJornadaIdAsync(1)).ReturnsAsync(new List<Partido> { partido });
+        _torneoService.Setup(s => s.DarDeBajaImpagosAsync(10)).ReturnsAsync(2);
+
+        var callOrder = new List<string>();
+        _torneoService
+            .Setup(s => s.DarDeBajaImpagosAsync(10))
+            .Callback(() => callOrder.Add("DarDeBaja"))
+            .ReturnsAsync(2);
+        _jornadaRepo
+            .Setup(r => r.UpdateAsync(It.IsAny<Jornada>()))
+            .Callback(() => callOrder.Add("UpdateJornada"));
+
+        var sut = BuildSut();
+
+        // Act
+        await sut.AbrirJornadaAsync(1);
+
+        // Assert: DarDeBaja was called, and BEFORE the jornada state was saved
+        _torneoService.Verify(s => s.DarDeBajaImpagosAsync(10), Times.Once);
+        callOrder.Should().ContainInOrder("DarDeBaja", "UpdateJornada");
+    }
+
+    [Fact]
+    public async Task AbrirJornada_NoUnpaidPlayers_StillTransitions()
+    {
+        // Arrange
+        var jornada = new Jornada { Id = 2, TorneoId = 10, Numero = 1, Estado = EstadoJornada.PendientePartidos };
+        var partido = new Partido
+        {
+            Id = 200, JornadaId = 2, Equipo1 = "C", Equipo2 = "D",
+            KickOffUtc = DateTime.UtcNow.AddDays(1)
+        };
+
+        _jornadaRepo.Setup(r => r.GetByIdAsync(2)).ReturnsAsync(jornada);
+        _partidoRepo.Setup(r => r.GetByJornadaIdAsync(2)).ReturnsAsync(new List<Partido> { partido });
+        _torneoService.Setup(s => s.DarDeBajaImpagosAsync(10)).ReturnsAsync(0);
+
+        var sut = BuildSut();
+
+        // Act
+        await sut.AbrirJornadaAsync(2);
+
+        // Assert
+        jornada.Estado.Should().Be(EstadoJornada.Abierta);
+        _torneoService.Verify(s => s.DarDeBajaImpagosAsync(10), Times.Once);
+    }
+}

--- a/BanterBotSports.Tests/Unit/TorneoServicePagoTests.cs
+++ b/BanterBotSports.Tests/Unit/TorneoServicePagoTests.cs
@@ -1,0 +1,225 @@
+using BanterBotSports.BL.Services;
+using BanterBotSports.DAL.Repositories.Interfaces;
+using BanterBotSports.Entities;
+using BanterBotSports.Entities.Enums;
+using FluentAssertions;
+using Moq;
+
+namespace BanterBotSports.Tests.Unit;
+
+/// <summary>
+/// Unit tests for TorneoService payment-related methods:
+/// ConfirmarPagoAsync, RevocarPagoAsync, DarDeBajaImpagosAsync.
+/// </summary>
+public class TorneoServicePagoTests
+{
+    private const string OrganizadorId = "org-user-id";
+    private const int TorneoId = 1;
+
+    private readonly Mock<ITorneoRepository> _torneoRepo = new();
+    private readonly Mock<IParticipanteRepository> _participanteRepo = new();
+    private readonly Mock<IJornadaRepository> _jornadaRepo = new();
+    private readonly Mock<IPrediccionRepository> _prediccionRepo = new();
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+
+    private TorneoService BuildSut() => new(
+        _torneoRepo.Object,
+        _participanteRepo.Object,
+        _jornadaRepo.Object,
+        _prediccionRepo.Object,
+        _unitOfWork.Object);
+
+    private Torneo BuildTorneo() => new()
+    {
+        Id = TorneoId,
+        Nombre = "Test Torneo",
+        OrganizadorId = OrganizadorId
+    };
+
+    // ---------------------------------------------------------------------------
+    // ConfirmarPagoAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ConfirmarPago_HappyPath_SetsPagoTrue()
+    {
+        var torneo = BuildTorneo();
+        var participante = new Participante { Id = 10, TorneoId = TorneoId, UserId = "player-1", Pago = false, Rol = RolParticipante.Jugador };
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoId)).ReturnsAsync(torneo);
+        _participanteRepo.Setup(r => r.GetByIdAsync(10)).ReturnsAsync(participante);
+
+        var sut = BuildSut();
+        await sut.ConfirmarPagoAsync(TorneoId, 10, OrganizadorId);
+
+        participante.Pago.Should().BeTrue();
+        _participanteRepo.Verify(r => r.UpdateAsync(participante), Times.Once);
+        _unitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConfirmarPago_AlreadyPaid_IsIdempotent()
+    {
+        var torneo = BuildTorneo();
+        var participante = new Participante { Id = 10, TorneoId = TorneoId, UserId = "player-1", Pago = true, Rol = RolParticipante.Jugador };
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoId)).ReturnsAsync(torneo);
+        _participanteRepo.Setup(r => r.GetByIdAsync(10)).ReturnsAsync(participante);
+
+        var sut = BuildSut();
+        await sut.ConfirmarPagoAsync(TorneoId, 10, OrganizadorId);
+
+        participante.Pago.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ConfirmarPago_NonOrganizer_ThrowsUnauthorized()
+    {
+        var torneo = BuildTorneo();
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoId)).ReturnsAsync(torneo);
+
+        var sut = BuildSut();
+        var act = () => sut.ConfirmarPagoAsync(TorneoId, 10, "random-user");
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ConfirmarPago_TorneoNotFound_ThrowsInvalidOperation()
+    {
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoId)).ReturnsAsync((Torneo?)null);
+
+        var sut = BuildSut();
+        var act = () => sut.ConfirmarPagoAsync(TorneoId, 10, OrganizadorId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task ConfirmarPago_ParticipanteNotFound_ThrowsInvalidOperation()
+    {
+        var torneo = BuildTorneo();
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoId)).ReturnsAsync(torneo);
+        _participanteRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>())).ReturnsAsync((Participante?)null);
+
+        var sut = BuildSut();
+        var act = () => sut.ConfirmarPagoAsync(TorneoId, 999, OrganizadorId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // ---------------------------------------------------------------------------
+    // RevocarPagoAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RevocarPago_HappyPath_SetsPagoFalse()
+    {
+        var torneo = BuildTorneo();
+        var participante = new Participante { Id = 10, TorneoId = TorneoId, UserId = "player-1", Pago = true, Rol = RolParticipante.Jugador };
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoId)).ReturnsAsync(torneo);
+        _participanteRepo.Setup(r => r.GetByIdAsync(10)).ReturnsAsync(participante);
+
+        var sut = BuildSut();
+        await sut.RevocarPagoAsync(TorneoId, 10, OrganizadorId);
+
+        participante.Pago.Should().BeFalse();
+        _participanteRepo.Verify(r => r.UpdateAsync(participante), Times.Once);
+        _unitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task RevocarPago_OrganizerSelf_ThrowsInvalidOperation()
+    {
+        var torneo = BuildTorneo();
+        var participante = new Participante { Id = 1, TorneoId = TorneoId, UserId = OrganizadorId, Pago = true, Rol = RolParticipante.Ambos };
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoId)).ReturnsAsync(torneo);
+        _participanteRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(participante);
+
+        var sut = BuildSut();
+        var act = () => sut.RevocarPagoAsync(TorneoId, 1, OrganizadorId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*organizador*");
+    }
+
+    [Fact]
+    public async Task RevocarPago_NonOrganizer_ThrowsUnauthorized()
+    {
+        var torneo = BuildTorneo();
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoId)).ReturnsAsync(torneo);
+
+        var sut = BuildSut();
+        var act = () => sut.RevocarPagoAsync(TorneoId, 10, "random-user");
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    // ---------------------------------------------------------------------------
+    // DarDeBajaImpagosAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task DarDeBajaImpagos_RemovesUnpaidAndDeletesPredictions()
+    {
+        var participantes = new List<Participante>
+        {
+            new() { Id = 1, TorneoId = TorneoId, UserId = OrganizadorId, Pago = true, Rol = RolParticipante.Ambos },
+            new() { Id = 2, TorneoId = TorneoId, UserId = "player-a", Pago = true, Rol = RolParticipante.Jugador },
+            new() { Id = 3, TorneoId = TorneoId, UserId = "player-b", Pago = false, Rol = RolParticipante.Jugador }
+        };
+
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoId))
+            .ReturnsAsync(participantes);
+
+        var sut = BuildSut();
+        var removed = await sut.DarDeBajaImpagosAsync(TorneoId);
+
+        removed.Should().Be(1);
+        _prediccionRepo.Verify(r => r.DeleteByParticipanteIdAsync(3), Times.Once);
+        _participanteRepo.Verify(r => r.DeleteAsync(It.Is<Participante>(p => p.Id == 3)), Times.Once);
+        _participanteRepo.Verify(r => r.DeleteAsync(It.Is<Participante>(p => p.Id == 1)), Times.Never);
+        _participanteRepo.Verify(r => r.DeleteAsync(It.Is<Participante>(p => p.Id == 2)), Times.Never);
+        _unitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DarDeBajaImpagos_AllPaid_ReturnsZeroAndDoesNotSave()
+    {
+        var participantes = new List<Participante>
+        {
+            new() { Id = 1, TorneoId = TorneoId, UserId = OrganizadorId, Pago = true, Rol = RolParticipante.Ambos },
+            new() { Id = 2, TorneoId = TorneoId, UserId = "player-a", Pago = true, Rol = RolParticipante.Jugador }
+        };
+
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoId))
+            .ReturnsAsync(participantes);
+
+        var sut = BuildSut();
+        var removed = await sut.DarDeBajaImpagosAsync(TorneoId);
+
+        removed.Should().Be(0);
+        _unitOfWork.Verify(u => u.SaveAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task DarDeBajaImpagos_OrganizerUnpaid_NeverRemovesOrganizer()
+    {
+        // Edge case: organizer somehow has Pago=false but Rol=Ambos — should NOT be removed
+        var participantes = new List<Participante>
+        {
+            new() { Id = 1, TorneoId = TorneoId, UserId = OrganizadorId, Pago = false, Rol = RolParticipante.Ambos }
+        };
+
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoId))
+            .ReturnsAsync(participantes);
+
+        var sut = BuildSut();
+        var removed = await sut.DarDeBajaImpagosAsync(TorneoId);
+
+        removed.Should().Be(0);
+        _participanteRepo.Verify(r => r.DeleteAsync(It.IsAny<Participante>()), Times.Never);
+    }
+}

--- a/BanterBotSports.Web/Controllers/TorneoController.cs
+++ b/BanterBotSports.Web/Controllers/TorneoController.cs
@@ -142,6 +142,62 @@ public class TorneoController : Controller
         return View(vm);
     }
 
+    // POST /torneo/{id}/confirmar-pago
+    [HttpPost("/torneo/{id:int}/confirmar-pago")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ConfirmarPago(int id, [FromForm] int participanteId)
+    {
+        var torneo = await _torneoService.GetByIdAsync(id);
+        if (torneo is null)
+            return NotFound();
+
+        var userId = _userManager.GetUserId(User)!;
+        if (torneo.OrganizadorId != userId)
+            return Forbid();
+
+        try
+        {
+            await _torneoService.ConfirmarPagoAsync(id, participanteId, userId);
+            TempData[TempDataKeys.Success] = "Pago confirmado.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Failed to confirm payment for participante {ParticipanteId} in torneo {TorneoId}", participanteId, id);
+            TempData[TempDataKeys.Error] = "No se pudo confirmar el pago.";
+        }
+
+        return RedirectToAction(nameof(Dashboard), new { id });
+    }
+
+    // POST /torneo/{id}/revocar-pago
+    [HttpPost("/torneo/{id:int}/revocar-pago")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RevocarPago(int id, [FromForm] int participanteId)
+    {
+        var torneo = await _torneoService.GetByIdAsync(id);
+        if (torneo is null)
+            return NotFound();
+
+        var userId = _userManager.GetUserId(User)!;
+        if (torneo.OrganizadorId != userId)
+            return Forbid();
+
+        try
+        {
+            await _torneoService.RevocarPagoAsync(id, participanteId, userId);
+            TempData[TempDataKeys.Success] = "Pago revocado.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Failed to revoke payment for participante {ParticipanteId} in torneo {TorneoId}", participanteId, id);
+            TempData[TempDataKeys.Error] = ex.Message.Contains("organizador")
+                ? "No se puede revocar el pago del organizador."
+                : "No se pudo revocar el pago.";
+        }
+
+        return RedirectToAction(nameof(Dashboard), new { id });
+    }
+
     // POST /torneo/{id}/unirse?token=X
     [HttpPost("/torneo/{id:int}/unirse")]
     [ValidateAntiForgeryToken]

--- a/BanterBotSports.Web/Views/Torneo/Dashboard.cshtml
+++ b/BanterBotSports.Web/Views/Torneo/Dashboard.cshtml
@@ -236,6 +236,83 @@
                 </div>
             }
         </section>
+
+        <!-- Player Payment Management (Organizer only) -->
+        @if (esOrganizador && Model.Participantes != null)
+        {
+            <section class="bg-[#0d1323] rounded-3xl overflow-hidden">
+                <div class="p-6 flex justify-between items-center">
+                    <h3 class="text-lg font-bold uppercase italic tracking-tight">Gestión de Pagos</h3>
+                    @{
+                        var pagados = Model.Participantes.Count(p => p.Pago);
+                        var totalJugadores = Model.Participantes.Count;
+                    }
+                    <span class="text-[10px] font-black uppercase text-[#a6aabf] tracking-[0.2em]">
+                        @pagados / @totalJugadores pagados
+                    </span>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="w-full text-left">
+                        <thead>
+                            <tr class="text-[10px] text-[#a6aabf] uppercase tracking-[0.2em] font-black bg-[#181f33]/30">
+                                <th class="px-6 py-4">Jugador</th>
+                                <th class="px-4 py-4">Rol</th>
+                                <th class="px-4 py-4 text-center">Estado</th>
+                                <th class="px-4 py-4 text-right">Acción</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var participante in Model.Participantes)
+                            {
+                                var displayName = ranking.FirstOrDefault(r => r.ParticipanteId == participante.Id)?.NombreDisplay ?? "Jugador";
+                                var isOrg = participante.Rol == RolParticipante.Ambos;
+                                var pagoClass = participante.Pago
+                                    ? "bg-[#2ff801]/10 text-[#2ff801]"
+                                    : "bg-red-500/10 text-red-400";
+                                <tr class="hover:bg-[#242b43]/20 transition-colors">
+                                    <td class="px-6 py-4 font-bold text-sm">@displayName</td>
+                                    <td class="px-4 py-4 text-xs text-[#a6aabf]">@participante.Rol</td>
+                                    <td class="px-4 py-4 text-center">
+                                        <span class="text-[10px] font-black px-3 py-1 rounded-full uppercase tracking-widest @pagoClass">
+                                            @(participante.Pago ? "Pagado" : "Pendiente")
+                                        </span>
+                                    </td>
+                                    <td class="px-4 py-4 text-right">
+                                        @if (!isOrg)
+                                        {
+                                            @if (!participante.Pago)
+                                            {
+                                                <form method="post" asp-action="ConfirmarPago" asp-route-id="@Model.Id" class="inline">
+                                                    <input type="hidden" name="participanteId" value="@participante.Id" />
+                                                    <button type="submit"
+                                                            class="px-3 py-1.5 bg-[#2ff801]/20 text-[#2ff801] rounded-lg text-[10px] font-black uppercase hover:bg-[#2ff801]/30 transition-colors">
+                                                        Confirmar
+                                                    </button>
+                                                </form>
+                                            }
+                                            else
+                                            {
+                                                <form method="post" asp-action="RevocarPago" asp-route-id="@Model.Id" class="inline">
+                                                    <input type="hidden" name="participanteId" value="@participante.Id" />
+                                                    <button type="submit"
+                                                            class="px-3 py-1.5 bg-red-500/20 text-red-400 rounded-lg text-[10px] font-black uppercase hover:bg-red-500/30 transition-colors">
+                                                        Revocar
+                                                    </button>
+                                                </form>
+                                            }
+                                        }
+                                        else
+                                        {
+                                            <span class="text-[10px] text-[#a6aabf]">Organizador</span>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        }
     </div>
 
     <!-- Sidebar: Prizes + Scoring — stacked below on mobile, sidebar on lg -->


### PR DESCRIPTION
## Summary
- Organizer can confirm/revoke player payments from the Dashboard
- Unpaid players (non-organizer) are automatically removed on jornada open
- All predictions of removed players are bulk-deleted before removal

## Changes
- `ITorneoService/TorneoService`: `ConfirmarPagoAsync`, `RevocarPagoAsync`, `DarDeBajaImpagosAsync`
- `IPrediccionRepository/PrediccionRepository`: `DeleteByParticipanteIdAsync`
- `JornadaService`: injects `ITorneoService`; calls `DarDeBajaImpagosAsync` in `AbrirJornadaAsync`
- `TorneoController`: POST `/torneo/{id}/confirmar-pago` and `/torneo/{id}/revocar-pago`
- `Dashboard.cshtml`: Gestión de Pagos section (organizer-only)

## Test plan
- [ ] All 92 unit tests pass
- [ ] ConfirmarPago happy path, idempotent, not-found, non-organizer
- [ ] RevocarPago happy path, organizer-self-guard, non-organizer
- [ ] DarDeBajaImpagosAsync removes unpaid players + predictions, keeps paid + organizer, no-op if no unpaid
- [ ] AbrirJornadaAsync calls DarDeBajaImpagosAsync before state transition