### PR TITLE
feat: wire SignalR ranking broadcast after live score update

### DIFF
--- a/BanterBotSports.BL/Services/Interfaces/IRankingBroadcaster.cs
+++ b/BanterBotSports.BL/Services/Interfaces/IRankingBroadcaster.cs
@@ -1,0 +1,16 @@
+using BanterBotSports.BL.Models;
+
+namespace BanterBotSports.BL.Services.Interfaces;
+
+/// <summary>
+/// Abstraction for broadcasting ranking updates to connected clients.
+/// Implemented in the Web layer via SignalR; consumed by Integrations layer.
+/// This interface lives in BL so Integrations can reference it without depending on Web.
+/// </summary>
+public interface IRankingBroadcaster
+{
+    /// <summary>
+    /// Broadcasts the updated ranking for a torneo to all connected clients.
+    /// </summary>
+    Task BroadcastRankingAsync(int torneoId, IReadOnlyList<RankingParticipante> ranking);
+}

--- a/BanterBotSports.Integrations/Hosted/ResultSyncService.cs
+++ b/BanterBotSports.Integrations/Hosted/ResultSyncService.cs
@@ -1,3 +1,4 @@
+using BanterBotSports.BL.Models;
 using BanterBotSports.BL.Services.Interfaces;
 using BanterBotSports.DAL.Repositories.Interfaces;
 using BanterBotSports.Entities.Enums;
@@ -75,6 +76,9 @@ public class ResultSyncService : IHostedService, IAsyncDisposable
             var partidoRepository = scope.ServiceProvider.GetRequiredService<IPartidoRepository>();
             var partidoService = scope.ServiceProvider.GetRequiredService<IPartidoService>();
             var apiFootballSyncService = scope.ServiceProvider.GetRequiredService<IApiFootballSyncService>();
+            var jornadaService = scope.ServiceProvider.GetRequiredService<IJornadaService>();
+            var torneoService = scope.ServiceProvider.GetRequiredService<ITorneoService>();
+            var rankingBroadcaster = scope.ServiceProvider.GetRequiredService<IRankingBroadcaster>();
 
             var activeMatches = await partidoRepository.GetByEstadoAsync(EstadoPartido.EnCurso);
 
@@ -119,6 +123,27 @@ public class ResultSyncService : IHostedService, IAsyncDisposable
                     _logger.LogInformation(
                         "Updated partido {PartidoId} ({Equipo1} vs {Equipo2}): {G1}-{G2} [{Estado}]",
                         partido.Id, partido.Equipo1, partido.Equipo2, goles1, goles2, liveScore.Estado);
+
+                    // Broadcast updated ranking to connected clients
+                    try
+                    {
+                        var jornada = await jornadaService.GetDetalleAsync(partido.JornadaId);
+                        if (jornada is not null)
+                        {
+                            var torneo = await torneoService.GetByIdWithDetailsAsync(jornada.TorneoId);
+                            if (torneo is not null)
+                            {
+                                var ranking = await torneoService.BuildRankingAsync(torneo);
+                                await rankingBroadcaster.BroadcastRankingAsync(jornada.TorneoId, ranking);
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex,
+                            "Error broadcasting ranking for partido {PartidoId} (jornada {JornadaId}).",
+                            partido.Id, partido.JornadaId);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/BanterBotSports.Tests/Unit/ResultSyncServiceTests.cs
+++ b/BanterBotSports.Tests/Unit/ResultSyncServiceTests.cs
@@ -1,0 +1,359 @@
+using BanterBotSports.BL.Models;
+using BanterBotSports.BL.Services.Interfaces;
+using BanterBotSports.DAL.Repositories.Interfaces;
+using BanterBotSports.Entities;
+using BanterBotSports.Entities.DTOs;
+using BanterBotSports.Entities.Enums;
+using BanterBotSports.Integrations.ApiFootball;
+using BanterBotSports.Integrations.Hosted;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BanterBotSports.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ResultSyncService ranking broadcast behavior.
+/// Tests verify that after a score change the ranking is broadcast,
+/// and that broadcast errors do not stop processing of remaining matches.
+/// </summary>
+public class ResultSyncServiceTests
+{
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private static Partido BuildPartido(int id = 1, int jornadaId = 10, string externalId = "999",
+        int? goles1 = null, int? goles2 = null, EstadoPartido estado = EstadoPartido.EnCurso)
+        => new()
+        {
+            Id = id,
+            JornadaId = jornadaId,
+            ExternalId = externalId,
+            Equipo1 = "River",
+            Equipo2 = "Boca",
+            KickOffUtc = DateTimeOffset.UtcNow,
+            GolesEquipo1Oficial = goles1,
+            GolesEquipo2Oficial = goles2,
+            Estado = estado,
+            Jornada = null!
+        };
+
+    private static Jornada BuildJornada(int id = 10, int torneoId = 5)
+        => new()
+        {
+            Id = id,
+            TorneoId = torneoId,
+            Numero = 1,
+            Estado = EstadoJornada.Abierta
+        };
+
+    private static Torneo BuildTorneo(int id = 5)
+        => new()
+        {
+            Id = id,
+            Nombre = "Test Torneo",
+            OrganizadorId = "user1",
+            Estado = EstadoTorneo.Activo,
+            PtosResultado = 3,
+            PtosMarcador = 5,
+            PtosGolesJornada = 2
+        };
+
+    private static IReadOnlyList<RankingParticipante> BuildRanking()
+        => new List<RankingParticipante>
+        {
+            new(ParticipanteId: 1, NombreDisplay: "Pepe", PuntosTotal: 9, Posicion: 1),
+            new(ParticipanteId: 2, NombreDisplay: "Juan", PuntosTotal: 6, Posicion: 2)
+        };
+
+    private static PartidoDto BuildLiveScore(int externalId, int goles1, int goles2,
+        EstadoPartido estado = EstadoPartido.EnCurso)
+        => new(Id: externalId, ExternalId: externalId.ToString(), Equipo1: "River", Equipo2: "Boca",
+            KickOffUtc: DateTimeOffset.UtcNow, GolesEquipo1: goles1, GolesEquipo2: goles2, Estado: estado);
+
+    /// <summary>
+    /// Builds a ResultSyncService with all dependencies mocked.
+    /// Returns the service and mock objects needed for assertions.
+    /// </summary>
+    private static (ResultSyncService sut,
+        Mock<IPartidoRepository> partidoRepoMock,
+        Mock<IPartidoService> partidoServiceMock,
+        Mock<IApiFootballSyncService> apiFootballMock,
+        Mock<IJornadaService> jornadaServiceMock,
+        Mock<ITorneoService> torneoServiceMock,
+        Mock<IRankingBroadcaster> broadcasterMock)
+        BuildSut(
+            IReadOnlyList<Partido>? activeMatches = null,
+            PartidoDto? liveScore = null,
+            Jornada? jornada = null,
+            Torneo? torneo = null,
+            IReadOnlyList<RankingParticipante>? ranking = null)
+    {
+        var partidoRepoMock = new Mock<IPartidoRepository>();
+        var partidoServiceMock = new Mock<IPartidoService>();
+        var apiFootballMock = new Mock<IApiFootballSyncService>();
+        var jornadaServiceMock = new Mock<IJornadaService>();
+        var torneoServiceMock = new Mock<ITorneoService>();
+        var broadcasterMock = new Mock<IRankingBroadcaster>();
+
+        // Setup defaults
+        partidoRepoMock
+            .Setup(r => r.GetByEstadoAsync(EstadoPartido.EnCurso))
+            .ReturnsAsync(activeMatches ?? new List<Partido>());
+
+        if (liveScore is not null)
+        {
+            apiFootballMock
+                .Setup(a => a.GetLiveScoreAsync(It.IsAny<int>()))
+                .ReturnsAsync(liveScore);
+        }
+
+        if (jornada is not null)
+        {
+            jornadaServiceMock
+                .Setup(j => j.GetDetalleAsync(jornada.Id))
+                .ReturnsAsync(jornada);
+        }
+
+        if (torneo is not null)
+        {
+            torneoServiceMock
+                .Setup(t => t.GetByIdWithDetailsAsync(torneo.Id))
+                .ReturnsAsync(torneo);
+        }
+
+        if (ranking is not null)
+        {
+            torneoServiceMock
+                .Setup(t => t.BuildRankingAsync(It.IsAny<Torneo>()))
+                .ReturnsAsync(ranking);
+        }
+
+        broadcasterMock
+            .Setup(b => b.BroadcastRankingAsync(It.IsAny<int>(), It.IsAny<IReadOnlyList<RankingParticipante>>()))
+            .Returns(Task.CompletedTask);
+
+        // Wire up service scope factory
+        var services = new ServiceCollection();
+        services.AddSingleton(partidoRepoMock.Object);
+        services.AddSingleton(partidoServiceMock.Object);
+        services.AddSingleton(apiFootballMock.Object);
+        services.AddSingleton(jornadaServiceMock.Object);
+        services.AddSingleton(torneoServiceMock.Object);
+        services.AddSingleton(broadcasterMock.Object);
+
+        var serviceProvider = services.BuildServiceProvider();
+        var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        var sut = new ResultSyncService(scopeFactory, NullLogger<ResultSyncService>.Instance);
+
+        return (sut, partidoRepoMock, partidoServiceMock, apiFootballMock,
+            jornadaServiceMock, torneoServiceMock, broadcasterMock);
+    }
+
+    // ─── Tests ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SyncLiveMatchResults_WhenScoreChanges_BroadcastsRankingWithCorrectTorneoId()
+    {
+        // Arrange
+        var partido = BuildPartido(id: 1, jornadaId: 10, externalId: "999", goles1: 0, goles2: 0);
+        var liveScore = BuildLiveScore(999, goles1: 1, goles2: 0); // score changed
+        var jornada = BuildJornada(id: 10, torneoId: 5);
+        var torneo = BuildTorneo(id: 5);
+        var ranking = BuildRanking();
+
+        var (sut, _, _, _, jornadaServiceMock, torneoServiceMock, broadcasterMock) =
+            BuildSut(
+                activeMatches: new List<Partido> { partido },
+                liveScore: liveScore,
+                jornada: jornada,
+                torneo: torneo,
+                ranking: ranking);
+
+        // Act — trigger sync via internal method by using IHostedService start + tick
+        // We invoke the sync directly by calling StartAsync and letting the service execute once.
+        // Since we can't tick the PeriodicTimer externally, we use the internal sync via reflection.
+        await InvokeSyncAsync(sut);
+
+        // Assert
+        broadcasterMock.Verify(
+            b => b.BroadcastRankingAsync(5, ranking),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncLiveMatchResults_WhenScoresUnchanged_DoesNotBroadcast()
+    {
+        // Arrange — partido already has goles 1-0, liveScore returns same 1-0, same state
+        var partido = BuildPartido(id: 1, jornadaId: 10, externalId: "999", goles1: 1, goles2: 0,
+            estado: EstadoPartido.EnCurso);
+        var liveScore = BuildLiveScore(999, goles1: 1, goles2: 0, estado: EstadoPartido.EnCurso);
+
+        var (sut, _, _, _, _, _, broadcasterMock) =
+            BuildSut(
+                activeMatches: new List<Partido> { partido },
+                liveScore: liveScore);
+
+        // Act
+        await InvokeSyncAsync(sut);
+
+        // Assert — no broadcast when scores are the same
+        broadcasterMock.Verify(
+            b => b.BroadcastRankingAsync(It.IsAny<int>(), It.IsAny<IReadOnlyList<RankingParticipante>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SyncLiveMatchResults_WhenBroadcastThrows_RemainingMatchesStillProcessed()
+    {
+        // Arrange — two matches, broadcaster throws on first, second should still be processed
+        var partido1 = BuildPartido(id: 1, jornadaId: 10, externalId: "100", goles1: 0, goles2: 0);
+        var partido2 = BuildPartido(id: 2, jornadaId: 20, externalId: "200", goles1: 0, goles2: 0);
+        var liveScore1 = BuildLiveScore(100, goles1: 1, goles2: 0); // score changed
+        var liveScore2 = BuildLiveScore(200, goles1: 2, goles2: 1); // score changed
+
+        var jornada1 = BuildJornada(id: 10, torneoId: 5);
+        var jornada2 = BuildJornada(id: 20, torneoId: 7);
+        var torneo1 = BuildTorneo(id: 5);
+        var torneo2 = BuildTorneo(id: 7);
+        var ranking = BuildRanking();
+
+        var partidoRepoMock = new Mock<IPartidoRepository>();
+        var partidoServiceMock = new Mock<IPartidoService>();
+        var apiFootballMock = new Mock<IApiFootballSyncService>();
+        var jornadaServiceMock = new Mock<IJornadaService>();
+        var torneoServiceMock = new Mock<ITorneoService>();
+        var broadcasterMock = new Mock<IRankingBroadcaster>();
+
+        partidoRepoMock
+            .Setup(r => r.GetByEstadoAsync(EstadoPartido.EnCurso))
+            .ReturnsAsync(new List<Partido> { partido1, partido2 });
+
+        apiFootballMock
+            .Setup(a => a.GetLiveScoreAsync(100))
+            .ReturnsAsync(liveScore1);
+        apiFootballMock
+            .Setup(a => a.GetLiveScoreAsync(200))
+            .ReturnsAsync(liveScore2);
+
+        jornadaServiceMock.Setup(j => j.GetDetalleAsync(10)).ReturnsAsync(jornada1);
+        jornadaServiceMock.Setup(j => j.GetDetalleAsync(20)).ReturnsAsync(jornada2);
+
+        torneoServiceMock.Setup(t => t.GetByIdWithDetailsAsync(5)).ReturnsAsync(torneo1);
+        torneoServiceMock.Setup(t => t.GetByIdWithDetailsAsync(7)).ReturnsAsync(torneo2);
+
+        torneoServiceMock
+            .Setup(t => t.BuildRankingAsync(It.IsAny<Torneo>()))
+            .ReturnsAsync(ranking);
+
+        // First broadcast throws, second should succeed
+        broadcasterMock
+            .SetupSequence(b => b.BroadcastRankingAsync(It.IsAny<int>(), It.IsAny<IReadOnlyList<RankingParticipante>>()))
+            .ThrowsAsync(new InvalidOperationException("SignalR failure"))
+            .Returns(Task.CompletedTask);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(partidoRepoMock.Object);
+        services.AddSingleton(partidoServiceMock.Object);
+        services.AddSingleton(apiFootballMock.Object);
+        services.AddSingleton(jornadaServiceMock.Object);
+        services.AddSingleton(torneoServiceMock.Object);
+        services.AddSingleton(broadcasterMock.Object);
+
+        var serviceProvider = services.BuildServiceProvider();
+        var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        var sut = new ResultSyncService(scopeFactory, NullLogger<ResultSyncService>.Instance);
+
+        // Act — must not throw
+        var act = async () => await InvokeSyncAsync(sut);
+        await act.Should().NotThrowAsync();
+
+        // Assert — second match was processed (broadcast called twice, once throwing)
+        broadcasterMock.Verify(
+            b => b.BroadcastRankingAsync(It.IsAny<int>(), It.IsAny<IReadOnlyList<RankingParticipante>>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task SyncLiveMatchResults_WhenGetDetalleAsyncThrows_ErrorLoggedAndSyncContinues()
+    {
+        // Arrange — two matches, GetDetalleAsync throws on first jornada
+        var partido1 = BuildPartido(id: 1, jornadaId: 10, externalId: "100", goles1: 0, goles2: 0);
+        var partido2 = BuildPartido(id: 2, jornadaId: 20, externalId: "200", goles1: 0, goles2: 0);
+        var liveScore1 = BuildLiveScore(100, goles1: 1, goles2: 0);
+        var liveScore2 = BuildLiveScore(200, goles1: 2, goles2: 1);
+
+        var jornada2 = BuildJornada(id: 20, torneoId: 7);
+        var torneo2 = BuildTorneo(id: 7);
+        var ranking = BuildRanking();
+
+        var partidoRepoMock = new Mock<IPartidoRepository>();
+        var partidoServiceMock = new Mock<IPartidoService>();
+        var apiFootballMock = new Mock<IApiFootballSyncService>();
+        var jornadaServiceMock = new Mock<IJornadaService>();
+        var torneoServiceMock = new Mock<ITorneoService>();
+        var broadcasterMock = new Mock<IRankingBroadcaster>();
+
+        partidoRepoMock
+            .Setup(r => r.GetByEstadoAsync(EstadoPartido.EnCurso))
+            .ReturnsAsync(new List<Partido> { partido1, partido2 });
+
+        apiFootballMock.Setup(a => a.GetLiveScoreAsync(100)).ReturnsAsync(liveScore1);
+        apiFootballMock.Setup(a => a.GetLiveScoreAsync(200)).ReturnsAsync(liveScore2);
+
+        // First jornada throws
+        jornadaServiceMock
+            .Setup(j => j.GetDetalleAsync(10))
+            .ThrowsAsync(new InvalidOperationException("DB error"));
+        jornadaServiceMock.Setup(j => j.GetDetalleAsync(20)).ReturnsAsync(jornada2);
+
+        torneoServiceMock.Setup(t => t.GetByIdWithDetailsAsync(7)).ReturnsAsync(torneo2);
+        torneoServiceMock.Setup(t => t.BuildRankingAsync(It.IsAny<Torneo>())).ReturnsAsync(ranking);
+
+        broadcasterMock
+            .Setup(b => b.BroadcastRankingAsync(It.IsAny<int>(), It.IsAny<IReadOnlyList<RankingParticipante>>()))
+            .Returns(Task.CompletedTask);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(partidoRepoMock.Object);
+        services.AddSingleton(partidoServiceMock.Object);
+        services.AddSingleton(apiFootballMock.Object);
+        services.AddSingleton(jornadaServiceMock.Object);
+        services.AddSingleton(torneoServiceMock.Object);
+        services.AddSingleton(broadcasterMock.Object);
+
+        var serviceProvider = services.BuildServiceProvider();
+        var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        var sut = new ResultSyncService(scopeFactory, NullLogger<ResultSyncService>.Instance);
+
+        // Act — must not throw even with GetDetalleAsync failing
+        var act = async () => await InvokeSyncAsync(sut);
+        await act.Should().NotThrowAsync();
+
+        // Assert — second match still had its ranking broadcast
+        broadcasterMock.Verify(
+            b => b.BroadcastRankingAsync(7, ranking),
+            Times.Once);
+    }
+
+    // ─── Test Infrastructure ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Invokes the private SyncLiveMatchResultsAsync via reflection
+    /// to test without needing to tick a PeriodicTimer.
+    /// </summary>
+    private static async Task InvokeSyncAsync(ResultSyncService sut)
+    {
+        var method = typeof(ResultSyncService)
+            .GetMethod("SyncLiveMatchResultsAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        method.Should().NotBeNull("SyncLiveMatchResultsAsync must exist on ResultSyncService");
+
+        var task = (Task)method!.Invoke(sut, new object[] { CancellationToken.None })!;
+        await task;
+    }
+}

--- a/BanterBotSports.Tests/Unit/SignalRRankingBroadcasterTests.cs
+++ b/BanterBotSports.Tests/Unit/SignalRRankingBroadcasterTests.cs
@@ -1,0 +1,68 @@
+using BanterBotSports.BL.Models;
+using BanterBotSports.Web.Hubs;
+using BanterBotSports.Web.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+
+namespace BanterBotSports.Tests.Unit;
+
+/// <summary>
+/// Unit tests for SignalRRankingBroadcaster.
+/// Verifies that it delegates to IHubContext&lt;TorneoHub&gt; sending "RankingActualizado".
+/// </summary>
+public class SignalRRankingBroadcasterTests
+{
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private static IReadOnlyList<RankingParticipante> BuildRanking(int count = 2)
+    {
+        return Enumerable.Range(1, count)
+            .Select(i => new RankingParticipante(
+                ParticipanteId: i,
+                NombreDisplay: $"Player{i}",
+                PuntosTotal: (count - i + 1) * 3,
+                Posicion: i))
+            .ToList();
+    }
+
+    // ─── Tests ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BroadcastRankingAsync_SendsRankingActualizadoToTorneoGroup()
+    {
+        // Arrange
+        var torneoId = 42;
+        var ranking = BuildRanking();
+
+        var clientsMock = new Mock<IHubClients>();
+        var clientProxyMock = new Mock<IClientProxy>();
+        var hubContextMock = new Mock<IHubContext<TorneoHub>>();
+
+        clientsMock
+            .Setup(c => c.Group($"torneo-{torneoId}"))
+            .Returns(clientProxyMock.Object);
+
+        hubContextMock.Setup(h => h.Clients).Returns(clientsMock.Object);
+
+        clientProxyMock
+            .Setup(p => p.SendCoreAsync(
+                "RankingActualizado",
+                It.Is<object?[]>(args => args.Length == 1 && args[0] == ranking),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = new SignalRRankingBroadcaster(hubContextMock.Object);
+
+        // Act
+        await sut.BroadcastRankingAsync(torneoId, ranking);
+
+        // Assert
+        clientProxyMock.Verify(
+            p => p.SendCoreAsync(
+                "RankingActualizado",
+                It.Is<object?[]>(args => args.Length == 1 && args[0] == ranking),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/BanterBotSports.Web/Infrastructure/SignalRRankingBroadcaster.cs
+++ b/BanterBotSports.Web/Infrastructure/SignalRRankingBroadcaster.cs
@@ -1,0 +1,25 @@
+using BanterBotSports.BL.Models;
+using BanterBotSports.BL.Services.Interfaces;
+using BanterBotSports.Web.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+namespace BanterBotSports.Web.Infrastructure;
+
+/// <summary>
+/// Web layer implementation of IRankingBroadcaster.
+/// Delegates broadcasting to TorneoHub via IHubContext.
+/// </summary>
+public sealed class SignalRRankingBroadcaster : IRankingBroadcaster
+{
+    private readonly IHubContext<TorneoHub> _hubContext;
+
+    public SignalRRankingBroadcaster(IHubContext<TorneoHub> hubContext)
+    {
+        ArgumentNullException.ThrowIfNull(hubContext);
+        _hubContext = hubContext;
+    }
+
+    /// <inheritdoc />
+    public Task BroadcastRankingAsync(int torneoId, IReadOnlyList<RankingParticipante> ranking)
+        => TorneoHub.BroadcastAsync(_hubContext, torneoId, ranking);
+}

--- a/BanterBotSports.Web/Program.cs
+++ b/BanterBotSports.Web/Program.cs
@@ -9,6 +9,7 @@ using BanterBotSports.Integrations.ApiFootball;
 using BanterBotSports.Integrations.Hosted;
 using BanterBotSports.Integrations.Telegram;
 using BanterBotSports.Web.Hubs;
+using BanterBotSports.Web.Infrastructure;
 using BanterBotSports.Web.Services;
 using BanterBotSports.Web.Telegram;
 using Microsoft.AspNetCore.Identity;
@@ -117,6 +118,9 @@ builder.Services.AddSingleton<TelegramUpdateQueue>();
 builder.Services.AddHostedService<TelegramUpdateWorker>();
 builder.Services.AddHostedService<DeadlineEnforcerService>();
 builder.Services.AddHostedService<ResultSyncService>();
+
+// ─── SignalR Infrastructure ──────────────────────────────────────────────────
+builder.Services.AddScoped<IRankingBroadcaster, SignalRRankingBroadcaster>();
 
 // ─── MVC + SignalR ───────────────────────────────────────────────────────────
 builder.Services.AddControllersWithViews();


### PR DESCRIPTION
## Summary
- Introduces `IRankingBroadcaster` interface in BL layer (avoids circular dep Integrations→Web)
- `SignalRRankingBroadcaster` in Web implements it via `IHubContext<TorneoHub>`
- `ResultSyncService` now calls broadcast after each score change: jornada → torneo → ranking → SignalR push
- Broadcast failures are isolated with try-catch — sync loop continues for remaining matches

## Test plan
- [ ] `dotnet test` — 151 tests pass (0 failed)
- [ ] Score change during live match pushes updated ranking to all connected browser clients
- [ ] Broadcast failure does not break the sync loop for other matches

## Files Changed
- `BanterBotSports.BL/Services/Interfaces/IRankingBroadcaster.cs` — new interface
- `BanterBotSports.Web/Infrastructure/SignalRRankingBroadcaster.cs` — new implementation
- `BanterBotSports.Integrations/Hosted/ResultSyncService.cs` — post-update broadcast block
- `BanterBotSports.Web/Program.cs` — DI registration
- `BanterBotSports.Tests/Unit/ResultSyncServiceTests.cs` — 4 new tests
- `BanterBotSports.Tests/Unit/SignalRRankingBroadcasterTests.cs` — 1 new test