### PR TITLE
feat(torneo): clonar jugadores de quiniela anterior

### DIFF
--- a/BanterBotSports.BL/Models/ClonarJugadoresResult.cs
+++ b/BanterBotSports.BL/Models/ClonarJugadoresResult.cs
@@ -1,0 +1,4 @@
+namespace BanterBotSports.BL.Models;
+
+/// <summary>Result of a player-cloning operation between two torneos.</summary>
+public record ClonarJugadoresResult(int Clonados, int Omitidos);

--- a/BanterBotSports.BL/Models/TorneoResumen.cs
+++ b/BanterBotSports.BL/Models/TorneoResumen.cs
@@ -1,0 +1,4 @@
+namespace BanterBotSports.BL.Models;
+
+/// <summary>Lightweight summary of a torneo for selection UIs.</summary>
+public record TorneoResumen(int Id, string Nombre, int CantidadJugadores);

--- a/BanterBotSports.BL/Services/Interfaces/ITorneoService.cs
+++ b/BanterBotSports.BL/Services/Interfaces/ITorneoService.cs
@@ -62,4 +62,17 @@ public interface ITorneoService
     /// Returns the number of participants removed.
     /// </summary>
     Task<int> DarDeBajaImpagosAsync(int torneoId);
+
+    /// <summary>
+    /// Returns torneos owned by the same organizer with Estado Activo or Finalizado,
+    /// excluding the specified torneo.
+    /// </summary>
+    Task<IReadOnlyList<TorneoResumen>> GetTorneosClonablesAsync(int excluirTorneoId, string organizadorId);
+
+    /// <summary>
+    /// Clones Jugador-role participants from source torneo into destination torneo.
+    /// Both torneos must belong to the same organizer. Sets Pago=false on all cloned rows.
+    /// Idempotent: already-enrolled users are skipped (counted as Omitidos).
+    /// </summary>
+    Task<ClonarJugadoresResult> ClonarJugadoresAsync(int torneoDestinoId, int torneoOrigenId, string organizadorId);
 }

--- a/BanterBotSports.BL/Services/TorneoService.cs
+++ b/BanterBotSports.BL/Services/TorneoService.cs
@@ -204,6 +204,68 @@ public class TorneoService : ITorneoService
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyList<TorneoResumen>> GetTorneosClonablesAsync(int excluirTorneoId, string organizadorId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(organizadorId);
+
+        var torneos = await _torneoRepository.GetByOrganizadorIdAsync(organizadorId);
+        var result = new List<TorneoResumen>();
+
+        foreach (var t in torneos)
+        {
+            if (t.Id == excluirTorneoId) continue;
+            if (t.Estado != EstadoTorneo.Activo && t.Estado != EstadoTorneo.Finalizado) continue;
+
+            var participantes = await _participanteRepository.GetByTorneoIdAsync(t.Id);
+            var cantJugadores = participantes.Count(p => p.Rol == RolParticipante.Jugador);
+            result.Add(new TorneoResumen(t.Id, t.Nombre, cantJugadores));
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<ClonarJugadoresResult> ClonarJugadoresAsync(int torneoDestinoId, int torneoOrigenId, string organizadorId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(organizadorId);
+
+        var torneoDestino = await _torneoRepository.GetByIdAsync(torneoDestinoId)
+            ?? throw new InvalidOperationException($"Torneo destino {torneoDestinoId} no encontrado.");
+        if (torneoDestino.OrganizadorId != organizadorId)
+            throw new UnauthorizedAccessException("Solo el organizador puede clonar jugadores en este torneo.");
+
+        var torneoOrigen = await _torneoRepository.GetByIdAsync(torneoOrigenId)
+            ?? throw new InvalidOperationException($"Torneo origen {torneoOrigenId} no encontrado.");
+        if (torneoOrigen.OrganizadorId != organizadorId)
+            throw new UnauthorizedAccessException("Ambos torneos deben pertenecer al mismo organizador.");
+
+        var participantesOrigen = await _participanteRepository.GetByTorneoIdAsync(torneoOrigenId);
+        var jugadores = participantesOrigen.Where(p => p.Rol == RolParticipante.Jugador).ToList();
+
+        var participantesDestino = await _participanteRepository.GetByTorneoIdAsync(torneoDestinoId);
+        var enrolledUserIds = participantesDestino.Select(p => p.UserId).ToHashSet();
+
+        int clonados = 0, omitidos = 0;
+        foreach (var jugador in jugadores)
+        {
+            if (enrolledUserIds.Contains(jugador.UserId)) { omitidos++; continue; }
+            await _participanteRepository.AddAsync(new Participante
+            {
+                TorneoId = torneoDestinoId,
+                UserId = jugador.UserId,
+                Rol = RolParticipante.Jugador,
+                Pago = false
+            });
+            clonados++;
+        }
+
+        if (clonados > 0)
+            await _unitOfWork.SaveAsync();
+
+        return new ClonarJugadoresResult(clonados, omitidos);
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<RankingParticipante>> BuildRankingAsync(Torneo torneo)
     {
         ArgumentNullException.ThrowIfNull(torneo);

--- a/BanterBotSports.Tests/Unit/TorneoControllerClonarTests.cs
+++ b/BanterBotSports.Tests/Unit/TorneoControllerClonarTests.cs
@@ -1,0 +1,221 @@
+using BanterBotSports.BL.Models;
+using BanterBotSports.BL.Services.Interfaces;
+using BanterBotSports.DAL;
+using BanterBotSports.Entities;
+using BanterBotSports.Integrations.ApiFootball;
+using BanterBotSports.Web.Controllers;
+using BanterBotSports.Web.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Security.Claims;
+
+namespace BanterBotSports.Tests.Unit;
+
+/// <summary>
+/// Unit tests for the GET and POST /torneo/{id}/clonar-jugadores actions
+/// introduced by the clonacion-jugadores feature.
+/// </summary>
+public class TorneoControllerClonarTests
+{
+    private const string OrganizadorId = "org-user-id";
+    private const string OtherUserId = "other-user-id";
+    private const int TorneoDestinoId = 1;
+    private const int TorneoOrigenId = 2;
+
+    // ---------------------------------------------------------------------------
+    // Factory
+    // ---------------------------------------------------------------------------
+
+    private static (TorneoController Controller, Mock<ITorneoService> TorneoSvc)
+        BuildSut(string userId = OrganizadorId)
+    {
+        var torneoSvc = new Mock<ITorneoService>();
+        var jornadaSvc = new Mock<IJornadaService>();
+        var apiSyncSvc = new Mock<IApiFootballSyncService>();
+        var partidoSvc = new Mock<IPartidoService>();
+        var dataProtectionProvider = new EphemeralDataProtectionProvider();
+
+        var userStoreMock = new Mock<IUserStore<AppUser>>();
+        var userManager = new Mock<UserManager<AppUser>>(
+            userStoreMock.Object, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        userManager
+            .Setup(um => um.GetUserId(It.IsAny<ClaimsPrincipal>()))
+            .Returns(userId);
+
+        var controller = new TorneoController(
+            torneoSvc.Object,
+            jornadaSvc.Object,
+            apiSyncSvc.Object,
+            partidoSvc.Object,
+            dataProtectionProvider,
+            userManager.Object,
+            NullLogger<TorneoController>.Instance);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        controller.TempData = new TempDataDictionary(
+            controller.ControllerContext.HttpContext,
+            Mock.Of<ITempDataProvider>());
+
+        return (controller, torneoSvc);
+    }
+
+    private static Torneo BuildTorneo(int id, string organizadorId = OrganizadorId)
+        => new() { Id = id, Nombre = $"Torneo {id}", OrganizadorId = organizadorId };
+
+    private static IReadOnlyList<TorneoResumen> BuildClonables()
+        => new List<TorneoResumen>
+        {
+            new(TorneoOrigenId, "Torneo Anterior", 5)
+        };
+
+    // ---------------------------------------------------------------------------
+    // GET ClonarJugadores
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GET_ClonarJugadores_OrganizerAccess_ReturnsViewWithTorneosClonables()
+    {
+        var (controller, torneoSvc) = BuildSut();
+        var torneo = BuildTorneo(TorneoDestinoId);
+        var clonables = BuildClonables();
+
+        torneoSvc.Setup(s => s.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneo);
+        torneoSvc.Setup(s => s.GetTorneosClonablesAsync(TorneoDestinoId, OrganizadorId))
+            .ReturnsAsync(clonables);
+
+        var result = await controller.ClonarJugadores(TorneoDestinoId);
+
+        result.Should().BeOfType<ViewResult>();
+        var view = (ViewResult)result;
+        view.Model.Should().Be(torneo);
+        ((IReadOnlyList<TorneoResumen>?)view.ViewData["TorneosClonables"]).Should().BeEquivalentTo(clonables);
+    }
+
+    [Fact]
+    public async Task GET_ClonarJugadores_NonOrganizer_ReturnsForbid()
+    {
+        var (controller, torneoSvc) = BuildSut(userId: OtherUserId);
+        var torneo = BuildTorneo(TorneoDestinoId, organizadorId: OrganizadorId);
+
+        torneoSvc.Setup(s => s.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneo);
+
+        var result = await controller.ClonarJugadores(TorneoDestinoId);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task GET_ClonarJugadores_TorneoNotFound_ReturnsNotFound()
+    {
+        var (controller, torneoSvc) = BuildSut();
+        torneoSvc.Setup(s => s.GetByIdAsync(TorneoDestinoId)).ReturnsAsync((Torneo?)null);
+
+        var result = await controller.ClonarJugadores(TorneoDestinoId);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    // ---------------------------------------------------------------------------
+    // POST ClonarJugadores
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task POST_ClonarJugadores_AllCloned_SetsTempDataSuccess_AndRedirects()
+    {
+        var (controller, torneoSvc) = BuildSut();
+        var torneo = BuildTorneo(TorneoDestinoId);
+
+        torneoSvc.Setup(s => s.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneo);
+        torneoSvc.Setup(s => s.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId))
+            .ReturnsAsync(new ClonarJugadoresResult(3, 0));
+
+        var result = await controller.ClonarJugadoresPost(TorneoDestinoId, TorneoOrigenId);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        var redirect = (RedirectToActionResult)result;
+        redirect.ActionName.Should().Be("Dashboard");
+        redirect.RouteValues!["id"].Should().Be(TorneoDestinoId);
+
+        controller.TempData[TempDataKeys.Success]!.ToString()
+            .Should().Be("Se clonaron 3 jugadores correctamente.");
+    }
+
+    [Fact]
+    public async Task POST_ClonarJugadores_SomeClonedSomeOmitted_SetsTempDataInfo_AndRedirects()
+    {
+        var (controller, torneoSvc) = BuildSut();
+        var torneo = BuildTorneo(TorneoDestinoId);
+
+        torneoSvc.Setup(s => s.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneo);
+        torneoSvc.Setup(s => s.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId))
+            .ReturnsAsync(new ClonarJugadoresResult(2, 1));
+
+        var result = await controller.ClonarJugadoresPost(TorneoDestinoId, TorneoOrigenId);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+
+        var message = controller.TempData[TempDataKeys.Info]!.ToString()!;
+        message.Should().Contain("Se clonaron 2 jugadores");
+        message.Should().Contain("1 ya estaba");
+    }
+
+    [Fact]
+    public async Task POST_ClonarJugadores_AllAlreadyEnrolled_SetsTempDataInfo_AndRedirects()
+    {
+        var (controller, torneoSvc) = BuildSut();
+        var torneo = BuildTorneo(TorneoDestinoId);
+
+        torneoSvc.Setup(s => s.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneo);
+        torneoSvc.Setup(s => s.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId))
+            .ReturnsAsync(new ClonarJugadoresResult(0, 3));
+
+        var result = await controller.ClonarJugadoresPost(TorneoDestinoId, TorneoOrigenId);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+
+        controller.TempData[TempDataKeys.Info]!.ToString()
+            .Should().Be("Todos los jugadores ya estaban inscritos.");
+    }
+
+    [Fact]
+    public async Task POST_ClonarJugadores_NoPlayersInSource_SetsTempDataInfo_AndRedirects()
+    {
+        var (controller, torneoSvc) = BuildSut();
+        var torneo = BuildTorneo(TorneoDestinoId);
+
+        torneoSvc.Setup(s => s.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneo);
+        torneoSvc.Setup(s => s.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId))
+            .ReturnsAsync(new ClonarJugadoresResult(0, 0));
+
+        var result = await controller.ClonarJugadoresPost(TorneoDestinoId, TorneoOrigenId);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+
+        controller.TempData[TempDataKeys.Info]!.ToString()
+            .Should().Be("El torneo origen no tiene jugadores para clonar.");
+    }
+
+    [Fact]
+    public async Task POST_ClonarJugadores_NonOrganizer_ReturnsForbid()
+    {
+        var (controller, torneoSvc) = BuildSut(userId: OtherUserId);
+        var torneo = BuildTorneo(TorneoDestinoId, organizadorId: OrganizadorId);
+
+        torneoSvc.Setup(s => s.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneo);
+
+        var result = await controller.ClonarJugadoresPost(TorneoDestinoId, TorneoOrigenId);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+}

--- a/BanterBotSports.Tests/Unit/TorneoServiceClonarTests.cs
+++ b/BanterBotSports.Tests/Unit/TorneoServiceClonarTests.cs
@@ -1,0 +1,291 @@
+using BanterBotSports.BL.Models;
+using BanterBotSports.BL.Services;
+using BanterBotSports.DAL.Repositories.Interfaces;
+using BanterBotSports.Entities;
+using BanterBotSports.Entities.Enums;
+using FluentAssertions;
+using Moq;
+
+namespace BanterBotSports.Tests.Unit;
+
+/// <summary>
+/// Unit tests for TorneoService cloning methods:
+/// GetTorneosClonablesAsync, ClonarJugadoresAsync.
+/// </summary>
+public class TorneoServiceClonarTests
+{
+    private const string OrganizadorId = "org-user-id";
+    private const int TorneoDestinoId = 1;
+    private const int TorneoOrigenId = 2;
+
+    private readonly Mock<ITorneoRepository> _torneoRepo = new();
+    private readonly Mock<IParticipanteRepository> _participanteRepo = new();
+    private readonly Mock<IJornadaRepository> _jornadaRepo = new();
+    private readonly Mock<IPrediccionRepository> _prediccionRepo = new();
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+
+    private TorneoService BuildSut() => new(
+        _torneoRepo.Object,
+        _participanteRepo.Object,
+        _jornadaRepo.Object,
+        _prediccionRepo.Object,
+        _unitOfWork.Object);
+
+    private static Torneo BuildTorneo(int id, string organizadorId = OrganizadorId, EstadoTorneo estado = EstadoTorneo.Activo)
+        => new() { Id = id, Nombre = $"Torneo {id}", OrganizadorId = organizadorId, Estado = estado };
+
+    private static Participante BuildParticipante(int id, int torneoId, string userId, RolParticipante rol = RolParticipante.Jugador, bool pago = false)
+        => new() { Id = id, TorneoId = torneoId, UserId = userId, Rol = rol, Pago = pago };
+
+    // ---------------------------------------------------------------------------
+    // ClonarJugadoresAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ClonarJugadores_HappyPath_TwoJugadores_Returns2Clonados0Omitidos_AddsX2SavesX1()
+    {
+        var torneoDestino = BuildTorneo(TorneoDestinoId);
+        var torneoOrigen = BuildTorneo(TorneoOrigenId);
+
+        var jugadoresOrigen = new List<Participante>
+        {
+            BuildParticipante(1, TorneoOrigenId, "userA"),
+            BuildParticipante(2, TorneoOrigenId, "userB")
+        };
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneoDestino);
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoOrigenId)).ReturnsAsync(torneoOrigen);
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoOrigenId)).ReturnsAsync(jugadoresOrigen);
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoDestinoId)).ReturnsAsync(new List<Participante>());
+        _participanteRepo.Setup(r => r.AddAsync(It.IsAny<Participante>()))
+            .ReturnsAsync((Participante p) => p);
+
+        var sut = BuildSut();
+        var result = await sut.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId);
+
+        result.Clonados.Should().Be(2);
+        result.Omitidos.Should().Be(0);
+
+        _participanteRepo.Verify(r => r.AddAsync(It.Is<Participante>(p =>
+            p.TorneoId == TorneoDestinoId &&
+            p.Rol == RolParticipante.Jugador &&
+            p.Pago == false)), Times.Exactly(2));
+
+        _unitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ClonarJugadores_SkipsAlreadyEnrolled_Returns1Clonado1Omitido()
+    {
+        var torneoDestino = BuildTorneo(TorneoDestinoId);
+        var torneoOrigen = BuildTorneo(TorneoOrigenId);
+
+        var jugadoresOrigen = new List<Participante>
+        {
+            BuildParticipante(1, TorneoOrigenId, "userA"),
+            BuildParticipante(2, TorneoOrigenId, "userB")
+        };
+
+        var participantesDestino = new List<Participante>
+        {
+            BuildParticipante(10, TorneoDestinoId, "userA")
+        };
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneoDestino);
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoOrigenId)).ReturnsAsync(torneoOrigen);
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoOrigenId)).ReturnsAsync(jugadoresOrigen);
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoDestinoId)).ReturnsAsync(participantesDestino);
+        _participanteRepo.Setup(r => r.AddAsync(It.IsAny<Participante>()))
+            .ReturnsAsync((Participante p) => p);
+
+        var sut = BuildSut();
+        var result = await sut.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId);
+
+        result.Clonados.Should().Be(1);
+        result.Omitidos.Should().Be(1);
+
+        _participanteRepo.Verify(r => r.AddAsync(It.Is<Participante>(p => p.UserId == "userB")), Times.Once);
+        _unitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ClonarJugadores_AllAlreadyEnrolled_Returns0Clonados_SaveNeverCalled()
+    {
+        var torneoDestino = BuildTorneo(TorneoDestinoId);
+        var torneoOrigen = BuildTorneo(TorneoOrigenId);
+
+        var jugadoresOrigen = new List<Participante>
+        {
+            BuildParticipante(1, TorneoOrigenId, "userA")
+        };
+
+        var participantesDestino = new List<Participante>
+        {
+            BuildParticipante(10, TorneoDestinoId, "userA")
+        };
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneoDestino);
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoOrigenId)).ReturnsAsync(torneoOrigen);
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoOrigenId)).ReturnsAsync(jugadoresOrigen);
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoDestinoId)).ReturnsAsync(participantesDestino);
+
+        var sut = BuildSut();
+        var result = await sut.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId);
+
+        result.Clonados.Should().Be(0);
+        result.Omitidos.Should().Be(1);
+
+        _participanteRepo.Verify(r => r.AddAsync(It.IsAny<Participante>()), Times.Never);
+        _unitOfWork.Verify(u => u.SaveAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task ClonarJugadores_ExcludesAmbosAndOrganizadorRoles_OnlyJugadorCloned()
+    {
+        var torneoDestino = BuildTorneo(TorneoDestinoId);
+        var torneoOrigen = BuildTorneo(TorneoOrigenId);
+
+        var participantesOrigen = new List<Participante>
+        {
+            BuildParticipante(1, TorneoOrigenId, "userAmbos", RolParticipante.Ambos),
+            BuildParticipante(2, TorneoOrigenId, "userOrg", RolParticipante.Organizador),
+            BuildParticipante(3, TorneoOrigenId, "userA", RolParticipante.Jugador)
+        };
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneoDestino);
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoOrigenId)).ReturnsAsync(torneoOrigen);
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoOrigenId)).ReturnsAsync(participantesOrigen);
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(TorneoDestinoId)).ReturnsAsync(new List<Participante>());
+        _participanteRepo.Setup(r => r.AddAsync(It.IsAny<Participante>()))
+            .ReturnsAsync((Participante p) => p);
+
+        var sut = BuildSut();
+        var result = await sut.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId);
+
+        result.Clonados.Should().Be(1);
+        result.Omitidos.Should().Be(0);
+
+        _participanteRepo.Verify(r => r.AddAsync(It.Is<Participante>(p => p.UserId == "userA")), Times.Once);
+        _unitOfWork.Verify(u => u.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ClonarJugadores_DestinoNotOwnedByOrganizer_ThrowsUnauthorizedAccessException()
+    {
+        var torneoDestino = BuildTorneo(TorneoDestinoId, organizadorId: "other-user");
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneoDestino);
+
+        var sut = BuildSut();
+        var act = () => sut.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ClonarJugadores_OrigenNotOwnedByOrganizer_ThrowsUnauthorizedAccessException()
+    {
+        var torneoDestino = BuildTorneo(TorneoDestinoId);
+        var torneoOrigen = BuildTorneo(TorneoOrigenId, organizadorId: "other-user");
+
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoDestinoId)).ReturnsAsync(torneoDestino);
+        _torneoRepo.Setup(r => r.GetByIdAsync(TorneoOrigenId)).ReturnsAsync(torneoOrigen);
+
+        var sut = BuildSut();
+        var act = () => sut.ClonarJugadoresAsync(TorneoDestinoId, TorneoOrigenId, OrganizadorId);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetTorneosClonablesAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetTorneosClonables_ReturnsActivoAndFinalizado_ExcludesCurrentTorneo()
+    {
+        var torneos = new List<Torneo>
+        {
+            BuildTorneo(1, estado: EstadoTorneo.Activo),   // excluido
+            BuildTorneo(2, estado: EstadoTorneo.Activo),
+            BuildTorneo(3, estado: EstadoTorneo.Finalizado)
+        };
+
+        _torneoRepo.Setup(r => r.GetByOrganizadorIdAsync(OrganizadorId)).ReturnsAsync(torneos);
+
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(2)).ReturnsAsync(new List<Participante>
+        {
+            BuildParticipante(1, 2, "userA")
+        });
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(3)).ReturnsAsync(new List<Participante>
+        {
+            BuildParticipante(2, 3, "userB")
+        });
+
+        var sut = BuildSut();
+        var result = await sut.GetTorneosClonablesAsync(excluirTorneoId: 1, OrganizadorId);
+
+        result.Should().HaveCount(2);
+        result.Select(t => t.Id).Should().Contain(new[] { 2, 3 });
+        result.Select(t => t.Id).Should().NotContain(1);
+    }
+
+    [Fact]
+    public async Task GetTorneosClonables_ExcludesPendienteAndCancelado()
+    {
+        var torneos = new List<Torneo>
+        {
+            BuildTorneo(10, estado: EstadoTorneo.Pendiente),
+            BuildTorneo(11, estado: EstadoTorneo.Cancelado)
+        };
+
+        _torneoRepo.Setup(r => r.GetByOrganizadorIdAsync(OrganizadorId)).ReturnsAsync(torneos);
+
+        var sut = BuildSut();
+        var result = await sut.GetTorneosClonablesAsync(excluirTorneoId: 99, OrganizadorId);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTorneosClonables_CantidadJugadores_CountsOnlyRolJugador()
+    {
+        var torneos = new List<Torneo>
+        {
+            BuildTorneo(2, estado: EstadoTorneo.Activo)
+        };
+
+        var participantes = new List<Participante>
+        {
+            BuildParticipante(1, 2, "userAmbos", RolParticipante.Ambos),
+            BuildParticipante(2, 2, "userA", RolParticipante.Jugador),
+            BuildParticipante(3, 2, "userB", RolParticipante.Jugador),
+            BuildParticipante(4, 2, "userOrg", RolParticipante.Organizador)
+        };
+
+        _torneoRepo.Setup(r => r.GetByOrganizadorIdAsync(OrganizadorId)).ReturnsAsync(torneos);
+        _participanteRepo.Setup(r => r.GetByTorneoIdAsync(2)).ReturnsAsync(participantes);
+
+        var sut = BuildSut();
+        var result = await sut.GetTorneosClonablesAsync(excluirTorneoId: 99, OrganizadorId);
+
+        result.Should().HaveCount(1);
+        result[0].CantidadJugadores.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetTorneosClonables_NoOtherTorneos_ReturnsEmpty()
+    {
+        var torneos = new List<Torneo>
+        {
+            BuildTorneo(1, estado: EstadoTorneo.Activo)
+        };
+
+        _torneoRepo.Setup(r => r.GetByOrganizadorIdAsync(OrganizadorId)).ReturnsAsync(torneos);
+
+        var sut = BuildSut();
+        var result = await sut.GetTorneosClonablesAsync(excluirTorneoId: 1, OrganizadorId);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/BanterBotSports.Web/Controllers/TorneoController.cs
+++ b/BanterBotSports.Web/Controllers/TorneoController.cs
@@ -318,6 +318,47 @@ public class TorneoController : Controller
         return RedirectToAction(nameof(Dashboard), new { id });
     }
 
+    // GET /torneo/{id}/clonar-jugadores
+    [HttpGet("/torneo/{id:int}/clonar-jugadores")]
+    public async Task<IActionResult> ClonarJugadores(int id)
+    {
+        var torneo = await _torneoService.GetByIdAsync(id);
+        if (torneo is null) return NotFound();
+
+        var userId = _userManager.GetUserId(User)!;
+        if (torneo.OrganizadorId != userId) return Forbid();
+
+        var torneosClonables = await _torneoService.GetTorneosClonablesAsync(id, userId);
+        ViewBag.TorneosClonables = torneosClonables;
+        return View(torneo);
+    }
+
+    // POST /torneo/{id}/clonar-jugadores
+    [HttpPost("/torneo/{id:int}/clonar-jugadores")]
+    [ValidateAntiForgeryToken]
+    [ActionName("ClonarJugadores")]
+    public async Task<IActionResult> ClonarJugadoresPost(int id, [FromForm] int torneoOrigenId)
+    {
+        var torneo = await _torneoService.GetByIdAsync(id);
+        if (torneo is null) return NotFound();
+
+        var userId = _userManager.GetUserId(User)!;
+        if (torneo.OrganizadorId != userId) return Forbid();
+
+        var result = await _torneoService.ClonarJugadoresAsync(id, torneoOrigenId, userId);
+
+        if (result.Clonados > 0 && result.Omitidos == 0)
+            TempData[TempDataKeys.Success] = $"Se clonaron {result.Clonados} jugadores correctamente.";
+        else if (result.Clonados > 0 && result.Omitidos > 0)
+            TempData[TempDataKeys.Info] = $"Se clonaron {result.Clonados} jugadores. {result.Omitidos} ya estaba(n) inscripto(s) y fue(ron) omitido(s).";
+        else if (result.Omitidos > 0)
+            TempData[TempDataKeys.Info] = "Todos los jugadores ya estaban inscritos.";
+        else
+            TempData[TempDataKeys.Info] = "El torneo origen no tiene jugadores para clonar.";
+
+        return RedirectToAction(nameof(Dashboard), new { id });
+    }
+
     // GET /torneo/buscar-partidos?liga={ligaId}
     [HttpGet("/torneo/buscar-partidos")]
     public async Task<IActionResult> BuscarPartidos(int liga)

--- a/BanterBotSports.Web/Views/Torneo/ClonarJugadores.cshtml
+++ b/BanterBotSports.Web/Views/Torneo/ClonarJugadores.cshtml
@@ -1,0 +1,69 @@
+@using BanterBotSports.BL.Models
+@model BanterBotSports.Entities.Torneo
+@{
+    ViewData["Title"] = "Clonar Jugadores";
+    var torneosClonables = ViewBag.TorneosClonables as IReadOnlyList<TorneoResumen> ?? Array.Empty<TorneoResumen>();
+}
+
+<header class="relative overflow-hidden rounded-3xl bg-[#0d1323] p-6 md:p-10 mb-8 shadow-[0_0_40px_rgba(105,218,255,0.05)]">
+    <div class="absolute top-0 right-0 w-64 h-64 bg-[#69daff]/10 blur-[100px] -mr-16 -mt-16 pointer-events-none"></div>
+    <div class="relative z-10">
+        <h1 class="text-3xl md:text-5xl font-black tracking-tighter text-[#e1e4fa] leading-none mb-2 uppercase italic">
+            Clonar Jugadores
+        </h1>
+        <p class="text-[#a6aabf] text-sm font-bold uppercase tracking-widest">
+            Quiniela destino: <span class="text-[#69daff]">@Model.Nombre</span>
+        </p>
+    </div>
+</header>
+
+<div class="bg-[#0d1323] rounded-3xl p-6 md:p-8">
+    @if (!torneosClonables.Any())
+    {
+        <div class="text-center py-12">
+            <span class="material-symbols-outlined text-[#a6aabf] text-5xl block mb-4">group_off</span>
+            <p class="text-[#a6aabf] font-bold uppercase tracking-widest text-sm">
+                No tenés quinielas anteriores con jugadores para clonar.
+            </p>
+        </div>
+    }
+    else
+    {
+        <p class="text-[#a6aabf] text-sm mb-6">
+            Seleccioná una quiniela de origen. Solo se copiarán jugadores que aún no estén inscriptos en <strong class="text-[#e1e4fa]">@Model.Nombre</strong>.
+        </p>
+
+        <form method="post" asp-action="ClonarJugadores" asp-route-id="@Model.Id">
+            @Html.AntiForgeryToken()
+
+            <div class="space-y-3 mb-8">
+                @foreach (var torneo in torneosClonables)
+                {
+                    <label class="flex items-center gap-4 p-5 bg-[#181f33] rounded-2xl border border-[#434759]/20 hover:border-[#69daff]/40 hover:bg-[#242b43] transition-all cursor-pointer has-[:checked]:border-[#69daff] has-[:checked]:bg-[#69daff]/5">
+                        <input type="radio" name="torneoOrigenId" value="@torneo.Id"
+                               class="w-4 h-4 accent-[#69daff]" required />
+                        <div class="flex-1">
+                            <span class="block font-bold text-[#e1e4fa] text-sm">@torneo.Nombre</span>
+                            <span class="text-[10px] font-black uppercase text-[#a6aabf] tracking-widest">
+                                @torneo.CantidadJugadores jugador@(torneo.CantidadJugadores != 1 ? "es" : "")
+                            </span>
+                        </div>
+                        <span class="material-symbols-outlined text-[#a6aabf] text-lg">group</span>
+                    </label>
+                }
+            </div>
+
+            <button type="submit"
+                    class="px-8 py-3 bg-gradient-to-r from-[#69daff] to-[#00cffc] text-[#004050] font-black rounded-xl text-sm uppercase tracking-tight shadow-[0_0_20px_rgba(105,218,255,0.3)] hover:scale-105 active:scale-95 transition-all">
+                Clonar Jugadores
+            </button>
+        </form>
+    }
+
+    <div class="mt-6">
+        <a asp-action="Dashboard" asp-route-id="@Model.Id"
+           class="px-6 py-3 bg-[#242b43] text-[#e1e4fa] font-bold rounded-xl text-sm uppercase tracking-tight hover:bg-[#1e253b] transition-colors inline-block">
+            Volver al Dashboard
+        </a>
+    </div>
+</div>

--- a/BanterBotSports.Web/Views/Torneo/Dashboard.cshtml
+++ b/BanterBotSports.Web/Views/Torneo/Dashboard.cshtml
@@ -80,6 +80,10 @@
                    class="px-6 py-3 bg-[#242b43] text-[#e1e4fa] font-bold rounded-xl text-sm uppercase tracking-tight hover:bg-[#1e253b] transition-colors">
                     Invitar Jugadores
                 </a>
+                <a asp-action="ClonarJugadores" asp-route-id="@Model.Id"
+                   class="px-6 py-3 bg-[#242b43] text-[#e1e4fa] font-bold rounded-xl text-sm uppercase tracking-tight hover:bg-[#1e253b] transition-colors">
+                    Clonar Jugadores
+                </a>
             }
             <a asp-action="Leaderboard" asp-route-id="@Model.Id"
                class="px-6 py-3 bg-gradient-to-r from-[#69daff] to-[#00cffc] text-[#004050] font-black rounded-xl text-sm uppercase tracking-tight shadow-[0_0_20px_rgba(105,218,255,0.3)] hover:scale-105 active:scale-95 transition-all">


### PR DESCRIPTION
## Linked Issue

Closes #44

---

## PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## Summary

- Agrega `ClonarJugadoresAsync` y `GetTorneosClonablesAsync` en `TorneoService` — clona jugadores (Rol=Jugador) de un torneo anterior con `Pago=false`, operación idempotente
- Expone `GET/POST /torneo/{id}/clonar-jugadores` en `TorneoController` con autorización por organizador y feedback via TempData
- Agrega botón "Clonar Jugadores" en `Dashboard.cshtml` (solo visible para el organizador) y nueva vista `ClonarJugadores.cshtml`

## Changes

| File | Change |
|------|--------|
| `BanterBotSports.BL/Models/ClonarJugadoresResult.cs` | Nuevo record `(int Clonados, int Omitidos)` |
| `BanterBotSports.BL/Models/TorneoResumen.cs` | Nuevo record `(int Id, string Nombre, int CantidadJugadores)` |
| `BanterBotSports.BL/Services/Interfaces/ITorneoService.cs` | +2 firmas |
| `BanterBotSports.BL/Services/TorneoService.cs` | +2 implementaciones |
| `BanterBotSports.Web/Controllers/TorneoController.cs` | +GET +POST `ClonarJugadores` |
| `BanterBotSports.Web/Views/Torneo/ClonarJugadores.cshtml` | Nueva vista |
| `BanterBotSports.Web/Views/Torneo/Dashboard.cshtml` | Botón organizer-only |
| `BanterBotSports.Tests/Unit/TorneoServiceClonarTests.cs` | 10 unit tests |
| `BanterBotSports.Tests/Unit/TorneoControllerClonarTests.cs` | 8 unit tests |

## Test Plan

- [x] `dotnet build` passes (0 errors, 0 warnings)
- [x] `dotnet test` passes (226/227 — 1 pre-existing failure de PR #40, no relacionado)
- [x] GGA pre-commit hook passed on all commits
- [x] Manually tested the affected functionality

---

## Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Issue Reference** | PR body contains `Closes #N` | ⏳ |
| **Issue Approved** | Linked issue has `status:approved` | ⏳ |
| **Type Label** | PR has exactly one `type:*` label | ⏳ |
| **Build** | `dotnet build` succeeds | ⏳ |

---

## Checklist

- [x] Linked an approved issue (`Closes #44`)
- [x] Added exactly one `type:*` label
- [x] All commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits
- [x] Entity names in Spanish (Torneo, Jornada, Partido, etc.)
- [x] No hardcoded point values or prize percentages
- [x] Async/await for all I/O operations

## Notes for Reviewers

GGA Strict TDD Mode requiere que los tests pasen antes de hacer commit — los tests RED y la implementación GREEN se consolidaron en commits únicos por fase para satisfacer el hook. El test fallando (`TorneoControllerTests`) es pre-existente de PR #40.