### PR TITLE
feat(admin): panel de administración — CRUD usuarios y configuración global

### DIFF
--- a/BanterBotSports.BL/AppRoles.cs
+++ b/BanterBotSports.BL/AppRoles.cs
@@ -1,0 +1,11 @@
+namespace BanterBotSports.BL;
+
+/// <summary>
+/// Well-known role name constants used across the application.
+/// Centralised here to prevent magic string literals in services and views.
+/// </summary>
+public static class AppRoles
+{
+    public const string Admin = "Admin";
+    public const string Jugador = "Jugador";
+}

--- a/BanterBotSports.BL/Models/AdminDtos.cs
+++ b/BanterBotSports.BL/Models/AdminDtos.cs
@@ -1,0 +1,13 @@
+namespace BanterBotSports.BL.Models;
+
+public record AdminUserDto(
+    string Id,
+    string? Phone,
+    string? Email,
+    string? NombreDisplay,
+    bool IsActive,
+    int TorneosOrganizados,
+    int TorneosParticipados,
+    DateTimeOffset? LockoutEnd);
+
+public record AdminUserEditDto(string? NombreDisplay, string? Email);

--- a/BanterBotSports.BL/Services/AdminService.cs
+++ b/BanterBotSports.BL/Services/AdminService.cs
@@ -1,0 +1,221 @@
+using BanterBotSports.BL.Models;
+using BanterBotSports.BL.Services.Interfaces;
+using BanterBotSports.DAL;
+using BanterBotSports.BL;
+using BanterBotSports.Entities;
+using BanterBotSports.Entities.Enums;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace BanterBotSports.BL.Services;
+
+/// <summary>
+/// Implements administrative operations: platform configuration and user management.
+/// </summary>
+public class AdminService : IAdminService
+{
+    private readonly AppDbContext _db;
+    private readonly UserManager<AppUser> _userManager;
+
+    public AdminService(AppDbContext db, UserManager<AppUser> userManager)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(userManager);
+        _db = db;
+        _userManager = userManager;
+    }
+
+    // ─── Configuracion ───────────────────────────────────────────────────────
+
+    public async Task<ConfiguracionGlobal> GetConfiguracionAsync()
+    {
+        var config = await _db.ConfiguracionGlobal.FirstOrDefaultAsync(c => c.Id == 1);
+        if (config is null)
+        {
+            config = new ConfiguracionGlobal
+            {
+                Id = 1,
+                PorcentajePlataforma = 10,
+                PorcentajeOrganizadorMin = 5,
+                PorcentajeOrganizadorMax = 30,
+                MontoInscripcionMinimo = 500
+            };
+        }
+        return config;
+    }
+
+    public async Task UpdateConfiguracionAsync(ConfiguracionGlobal config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (config.PorcentajePlataforma <= 0 ||
+            config.PorcentajeOrganizadorMin <= 0 ||
+            config.PorcentajeOrganizadorMax <= 0 ||
+            config.MontoInscripcionMinimo <= 0)
+            throw new ArgumentException("Todos los valores deben ser mayores a cero.");
+
+        if (config.PorcentajePlataforma > 50)
+            throw new ArgumentException("El porcentaje de plataforma no puede superar el 50%.");
+
+        if (config.PorcentajeOrganizadorMin > config.PorcentajeOrganizadorMax)
+            throw new ArgumentException("El porcentaje mínimo del organizador no puede ser mayor al máximo.");
+
+        var existing = await _db.ConfiguracionGlobal.FindAsync(config.Id);
+        if (existing is not null)
+        {
+            existing.PorcentajePlataforma = config.PorcentajePlataforma;
+            existing.PorcentajeOrganizadorMin = config.PorcentajeOrganizadorMin;
+            existing.PorcentajeOrganizadorMax = config.PorcentajeOrganizadorMax;
+            existing.MontoInscripcionMinimo = config.MontoInscripcionMinimo;
+        }
+        else
+        {
+            _db.ConfiguracionGlobal.Add(config);
+        }
+        await _db.SaveChangesAsync();
+    }
+
+    // ─── Organizadores ───────────────────────────────────────────────────────
+
+    public async Task<IReadOnlyList<AdminUserDto>> GetOrganizadoresAsync()
+    {
+        var organizadorIds = await _db.Torneos
+            .Select(t => t.OrganizadorId)
+            .Distinct()
+            .ToListAsync();
+
+        var users = await _db.Users
+            .Where(u => organizadorIds.Contains(u.Id))
+            .ToListAsync();
+
+        var result = new List<AdminUserDto>();
+        foreach (var user in users)
+        {
+            var torneosOrg = await _db.Torneos.CountAsync(t => t.OrganizadorId == user.Id);
+            var torneosParticipados = await _db.Set<Participante>().CountAsync(p => p.UserId == user.Id);
+            var isActive = user.LockoutEnd == null || user.LockoutEnd < DateTimeOffset.UtcNow;
+            result.Add(new AdminUserDto(user.Id, user.PhoneNumber, user.Email, user.NombreDisplay, isActive, torneosOrg, torneosParticipados, user.LockoutEnd));
+        }
+        return result;
+    }
+
+    public async Task<AdminUserDto?> GetOrganizadorAsync(string userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user is null) return null;
+
+        var torneosOrg = await _db.Torneos.CountAsync(t => t.OrganizadorId == userId);
+        var torneosParticipados = await _db.Set<Participante>().CountAsync(p => p.UserId == userId);
+        var isActive = user.LockoutEnd == null || user.LockoutEnd < DateTimeOffset.UtcNow;
+        return new AdminUserDto(user.Id, user.PhoneNumber, user.Email, user.NombreDisplay, isActive, torneosOrg, torneosParticipados, user.LockoutEnd);
+    }
+
+    public async Task UpdateOrganizadorAsync(string userId, AdminUserEditDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+        var user = await _userManager.FindByIdAsync(userId)
+            ?? throw new InvalidOperationException($"Usuario '{userId}' no encontrado.");
+        user.NombreDisplay = dto.NombreDisplay;
+        user.Email = dto.Email;
+        user.UserName = dto.Email;
+        await _userManager.UpdateAsync(user);
+    }
+
+    public async Task DeactivateOrganizadorAsync(string userId)
+    {
+        var hasActiveTorneos = await _db.Torneos.AnyAsync(
+            t => t.OrganizadorId == userId &&
+                 (t.Estado == EstadoTorneo.Activo || t.Estado == EstadoTorneo.Pendiente));
+
+        if (hasActiveTorneos)
+            throw new InvalidOperationException(
+                "No se puede desactivar al organizador mientras tiene torneos activos o pendientes.");
+
+        var user = await _userManager.FindByIdAsync(userId)
+            ?? throw new InvalidOperationException($"Usuario '{userId}' no encontrado.");
+
+        user.LockoutEnabled = true;
+        user.LockoutEnd = DateTimeOffset.MaxValue;
+        await _userManager.UpdateAsync(user);
+    }
+
+    public async Task ReactivateUserAsync(string userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId)
+            ?? throw new InvalidOperationException($"Usuario '{userId}' no encontrado.");
+
+        user.LockoutEnd = null;
+        await _userManager.UpdateAsync(user);
+    }
+
+    // ─── Jugadores ───────────────────────────────────────────────────────────
+
+    public async Task<IReadOnlyList<AdminUserDto>> GetJugadoresAsync(string? search = null)
+    {
+        var adminUsers = await _userManager.GetUsersInRoleAsync(AppRoles.Admin);
+        var adminIds = adminUsers.Select(u => u.Id).ToHashSet();
+
+        IQueryable<AppUser> query = _db.Users.Where(u => !adminIds.Contains(u.Id));
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var dbName = _db.Database.ProviderName ?? string.Empty;
+            if (dbName.Contains("Npgsql", StringComparison.OrdinalIgnoreCase))
+            {
+                query = query.Where(u =>
+                    EF.Functions.ILike(u.PhoneNumber!, $"%{search}%") ||
+                    EF.Functions.ILike(u.NombreDisplay!, $"%{search}%"));
+            }
+            else
+            {
+                var lowerSearch = search.ToLower();
+                query = query.Where(u =>
+                    (u.PhoneNumber != null && u.PhoneNumber.ToLower().Contains(lowerSearch)) ||
+                    (u.NombreDisplay != null && u.NombreDisplay.ToLower().Contains(lowerSearch)));
+            }
+        }
+
+        var users = await query.ToListAsync();
+        var result = new List<AdminUserDto>();
+        foreach (var user in users)
+        {
+            var torneosOrg = await _db.Torneos.CountAsync(t => t.OrganizadorId == user.Id);
+            var torneosParticipados = await _db.Set<Participante>().CountAsync(p => p.UserId == user.Id);
+            var isActive = user.LockoutEnd == null || user.LockoutEnd < DateTimeOffset.UtcNow;
+            result.Add(new AdminUserDto(user.Id, user.PhoneNumber, user.Email, user.NombreDisplay, isActive, torneosOrg, torneosParticipados, user.LockoutEnd));
+        }
+        return result;
+    }
+
+    public async Task<AdminUserDto?> GetJugadorAsync(string userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user is null) return null;
+
+        var torneosOrg = await _db.Torneos.CountAsync(t => t.OrganizadorId == userId);
+        var torneosParticipados = await _db.Set<Participante>().CountAsync(p => p.UserId == userId);
+        var isActive = user.LockoutEnd == null || user.LockoutEnd < DateTimeOffset.UtcNow;
+        return new AdminUserDto(user.Id, user.PhoneNumber, user.Email, user.NombreDisplay, isActive, torneosOrg, torneosParticipados, user.LockoutEnd);
+    }
+
+    public async Task UpdateJugadorAsync(string userId, AdminUserEditDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+        var user = await _userManager.FindByIdAsync(userId)
+            ?? throw new InvalidOperationException($"Usuario '{userId}' no encontrado.");
+        user.NombreDisplay = dto.NombreDisplay;
+        user.Email = dto.Email;
+        user.UserName = dto.Email;
+        await _userManager.UpdateAsync(user);
+    }
+
+    public async Task DeactivateJugadorAsync(string userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId)
+            ?? throw new InvalidOperationException($"Usuario '{userId}' no encontrado.");
+
+        user.LockoutEnabled = true;
+        user.LockoutEnd = DateTimeOffset.MaxValue;
+        await _userManager.UpdateAsync(user);
+    }
+}

--- a/BanterBotSports.BL/Services/Interfaces/IAdminService.cs
+++ b/BanterBotSports.BL/Services/Interfaces/IAdminService.cs
@@ -1,0 +1,43 @@
+using BanterBotSports.BL.Models;
+using BanterBotSports.Entities;
+
+namespace BanterBotSports.BL.Services.Interfaces;
+
+/// <summary>
+/// Provides administrative operations for platform configuration and user management.
+/// </summary>
+public interface IAdminService
+{
+    /// <summary>Gets the global platform configuration (Id=1). Returns defaults if not seeded.</summary>
+    Task<ConfiguracionGlobal> GetConfiguracionAsync();
+
+    /// <summary>Validates and persists the global platform configuration.</summary>
+    Task UpdateConfiguracionAsync(ConfiguracionGlobal config);
+
+    /// <summary>Returns all users who have organised at least one torneo.</summary>
+    Task<IReadOnlyList<AdminUserDto>> GetOrganizadoresAsync();
+
+    /// <summary>Returns a single organiser by user ID, or null if not found.</summary>
+    Task<AdminUserDto?> GetOrganizadorAsync(string userId);
+
+    /// <summary>Updates NombreDisplay and Email for an organiser.</summary>
+    Task UpdateOrganizadorAsync(string userId, AdminUserEditDto dto);
+
+    /// <summary>Locks an organiser account. Throws <see cref="InvalidOperationException"/> if they have active/pending torneos.</summary>
+    Task DeactivateOrganizadorAsync(string userId);
+
+    /// <summary>Clears lockout on any user (organiser or player).</summary>
+    Task ReactivateUserAsync(string userId);
+
+    /// <summary>Returns all non-admin users, optionally filtered by phone or display name.</summary>
+    Task<IReadOnlyList<AdminUserDto>> GetJugadoresAsync(string? search = null);
+
+    /// <summary>Returns a single player by user ID, or null if not found.</summary>
+    Task<AdminUserDto?> GetJugadorAsync(string userId);
+
+    /// <summary>Updates NombreDisplay and Email for a player.</summary>
+    Task UpdateJugadorAsync(string userId, AdminUserEditDto dto);
+
+    /// <summary>Locks a player account.</summary>
+    Task DeactivateJugadorAsync(string userId);
+}

--- a/BanterBotSports.DAL/AppDbContext.cs
+++ b/BanterBotSports.DAL/AppDbContext.cs
@@ -17,6 +17,7 @@ public class AppDbContext : IdentityDbContext<AppUser>
     public DbSet<PrediccionPartido> PrediccionesPartido => Set<PrediccionPartido>();
     public DbSet<PrediccionJornada> PrediccionesJornada => Set<PrediccionJornada>();
     public DbSet<MensajeChat> MensajesChat => Set<MensajeChat>();
+    public DbSet<ConfiguracionGlobal> ConfiguracionGlobal => Set<ConfiguracionGlobal>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -29,6 +30,22 @@ public class AppDbContext : IdentityDbContext<AppUser>
 
         builder.Entity<ConfiguracionPremio>()
             .Property(c => c.Porcentaje)
+            .HasPrecision(18, 2);
+
+        builder.Entity<ConfiguracionGlobal>()
+            .Property(c => c.PorcentajePlataforma)
+            .HasPrecision(18, 2);
+
+        builder.Entity<ConfiguracionGlobal>()
+            .Property(c => c.PorcentajeOrganizadorMin)
+            .HasPrecision(18, 2);
+
+        builder.Entity<ConfiguracionGlobal>()
+            .Property(c => c.PorcentajeOrganizadorMax)
+            .HasPrecision(18, 2);
+
+        builder.Entity<ConfiguracionGlobal>()
+            .Property(c => c.MontoInscripcionMinimo)
             .HasPrecision(18, 2);
 
         // Unique index: one Telegram account per user

--- a/BanterBotSports.DAL/Migrations/20260408122430_AddConfiguracionGlobalAndRoles.Designer.cs
+++ b/BanterBotSports.DAL/Migrations/20260408122430_AddConfiguracionGlobalAndRoles.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BanterBotSports.DAL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BanterBotSports.DAL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408122430_AddConfiguracionGlobalAndRoles")]
+    partial class AddConfiguracionGlobalAndRoles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BanterBotSports.DAL/Migrations/20260408122430_AddConfiguracionGlobalAndRoles.cs
+++ b/BanterBotSports.DAL/Migrations/20260408122430_AddConfiguracionGlobalAndRoles.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace BanterBotSports.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfiguracionGlobalAndRoles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ConfiguracionGlobal",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    PorcentajePlataforma = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false),
+                    PorcentajeOrganizadorMin = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false),
+                    PorcentajeOrganizadorMax = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false),
+                    MontoInscripcionMinimo = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConfiguracionGlobal", x => x.Id);
+                });
+
+            // Seed default configuration row
+            migrationBuilder.InsertData(
+                table: "ConfiguracionGlobal",
+                columns: new[] { "Id", "PorcentajePlataforma", "PorcentajeOrganizadorMin", "PorcentajeOrganizadorMax", "MontoInscripcionMinimo" },
+                values: new object[] { 1, 10m, 5m, 30m, 500m });
+
+            // Seed Admin and Jugador roles
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "Name", "NormalizedName", "ConcurrencyStamp" },
+                values: new object[,]
+                {
+                    { "a1b2c3d4-e5f6-7890-abcd-ef1234567890", "Admin", "ADMIN", "a1b2c3d4-e5f6-7890-abcd-ef1234567890" },
+                    { "b2c3d4e5-f6a7-8901-bcde-f12345678901", "Jugador", "JUGADOR", "b2c3d4e5-f6a7-8901-bcde-f12345678901" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValues: new object[] { "a1b2c3d4-e5f6-7890-abcd-ef1234567890", "b2c3d4e5-f6a7-8901-bcde-f12345678901" });
+
+            migrationBuilder.DropTable(
+                name: "ConfiguracionGlobal");
+        }
+    }
+}

--- a/BanterBotSports.Entities/ConfiguracionGlobal.cs
+++ b/BanterBotSports.Entities/ConfiguracionGlobal.cs
@@ -1,0 +1,10 @@
+namespace BanterBotSports.Entities;
+
+public class ConfiguracionGlobal
+{
+    public int Id { get; set; }                           // Always 1
+    public decimal PorcentajePlataforma { get; set; }     // Default 10
+    public decimal PorcentajeOrganizadorMin { get; set; } // Default 5
+    public decimal PorcentajeOrganizadorMax { get; set; } // Default 30
+    public decimal MontoInscripcionMinimo { get; set; }   // Default 500
+}

--- a/BanterBotSports.Tests/Unit/AdminControllerTests.cs
+++ b/BanterBotSports.Tests/Unit/AdminControllerTests.cs
@@ -42,7 +42,7 @@ public class AdminControllerTests
     // ─── Index ───────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task GET_Index_ReturnsView()
+    public void GET_Index_ReturnsView()
     {
         var (controller, _) = BuildSut();
         var result = controller.Index();

--- a/BanterBotSports.Tests/Unit/AdminControllerTests.cs
+++ b/BanterBotSports.Tests/Unit/AdminControllerTests.cs
@@ -1,0 +1,277 @@
+using BanterBotSports.BL.Models;
+using BanterBotSports.BL.Services.Interfaces;
+using BanterBotSports.Entities;
+using BanterBotSports.Web.Controllers;
+using BanterBotSports.Web.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Moq;
+
+namespace BanterBotSports.Tests.Unit;
+
+/// <summary>
+/// Unit tests for AdminController.
+/// Follows the BuildSut + TempDataDictionary pattern from TorneoControllerClonarTests.
+/// </summary>
+public class AdminControllerTests
+{
+    // ─── Factory ─────────────────────────────────────────────────────────────
+
+    private static (AdminController Controller, Mock<IAdminService> AdminSvc) BuildSut()
+    {
+        var adminSvc = new Mock<IAdminService>();
+        var controller = new AdminController(adminSvc.Object);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        controller.TempData = new TempDataDictionary(
+            controller.ControllerContext.HttpContext,
+            Mock.Of<ITempDataProvider>());
+
+        return (controller, adminSvc);
+    }
+
+    private static AdminUserDto BuildDto(string id = "user1", bool isActive = true)
+        => new(id, "5551234567", "user@email.com", "Test User", isActive, 2, 3, null);
+
+    // ─── Index ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GET_Index_ReturnsView()
+    {
+        var (controller, _) = BuildSut();
+        var result = controller.Index();
+        result.Should().BeOfType<ViewResult>();
+    }
+
+    // ─── Organizadores ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GET_Organizadores_ReturnsViewWithList()
+    {
+        var (controller, adminSvc) = BuildSut();
+        var list = new List<AdminUserDto> { BuildDto() };
+        adminSvc.Setup(s => s.GetOrganizadoresAsync()).ReturnsAsync(list);
+
+        var result = await controller.Organizadores();
+
+        result.Should().BeOfType<ViewResult>();
+        var view = (ViewResult)result;
+        view.Model.Should().Be(list);
+    }
+
+    [Fact]
+    public async Task GET_EditOrganizador_NotFound_ReturnsNotFound()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.GetOrganizadorAsync("missing")).ReturnsAsync((AdminUserDto?)null);
+
+        var result = await controller.EditOrganizador("missing");
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GET_EditOrganizador_Found_ReturnsViewWithDto()
+    {
+        var (controller, adminSvc) = BuildSut();
+        var dto = BuildDto();
+        adminSvc.Setup(s => s.GetOrganizadorAsync("user1")).ReturnsAsync(dto);
+
+        var result = await controller.EditOrganizador("user1");
+
+        result.Should().BeOfType<ViewResult>();
+        ((ViewResult)result).Model.Should().Be(dto);
+    }
+
+    [Fact]
+    public async Task POST_EditOrganizador_Valid_RedirectsWithSuccess()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.UpdateOrganizadorAsync("user1", It.IsAny<AdminUserEditDto>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await controller.EditOrganizadorPost("user1", new AdminUserEditDto("NewName", "new@email.com"));
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        ((RedirectToActionResult)result).ActionName.Should().Be("Organizadores");
+        controller.TempData[TempDataKeys.Success].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task POST_DeactivateOrganizador_Success_RedirectsWithSuccess()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.DeactivateOrganizadorAsync("user1")).Returns(Task.CompletedTask);
+
+        var result = await controller.DeactivateOrganizador("user1");
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        ((RedirectToActionResult)result).ActionName.Should().Be("Organizadores");
+        controller.TempData[TempDataKeys.Success].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task POST_DeactivateOrganizador_InvalidOperation_SetsErrorTempData_AndRedirects()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.DeactivateOrganizadorAsync("user1"))
+            .ThrowsAsync(new InvalidOperationException("Tiene torneos activos."));
+
+        var result = await controller.DeactivateOrganizador("user1");
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        controller.TempData[TempDataKeys.Error].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task POST_ReactivateOrganizador_Success_RedirectsWithSuccess()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.ReactivateUserAsync("user1")).Returns(Task.CompletedTask);
+
+        var result = await controller.ReactivateOrganizador("user1");
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        ((RedirectToActionResult)result).ActionName.Should().Be("Organizadores");
+        controller.TempData[TempDataKeys.Success].Should().NotBeNull();
+    }
+
+    // ─── Jugadores ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GET_Jugadores_ReturnsViewWithList()
+    {
+        var (controller, adminSvc) = BuildSut();
+        var list = new List<AdminUserDto> { BuildDto() };
+        adminSvc.Setup(s => s.GetJugadoresAsync(null)).ReturnsAsync(list);
+
+        var result = await controller.Jugadores(null);
+
+        result.Should().BeOfType<ViewResult>();
+        ((ViewResult)result).Model.Should().Be(list);
+    }
+
+    [Fact]
+    public async Task GET_Jugadores_WithSearch_PassesSearchToService()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.GetJugadoresAsync("carlos")).ReturnsAsync(new List<AdminUserDto>());
+
+        var result = await controller.Jugadores("carlos");
+
+        adminSvc.Verify(s => s.GetJugadoresAsync("carlos"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GET_EditJugador_NotFound_ReturnsNotFound()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.GetJugadorAsync("missing")).ReturnsAsync((AdminUserDto?)null);
+
+        var result = await controller.EditJugador("missing");
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GET_EditJugador_Found_ReturnsViewWithDto()
+    {
+        var (controller, adminSvc) = BuildSut();
+        var dto = BuildDto();
+        adminSvc.Setup(s => s.GetJugadorAsync("user1")).ReturnsAsync(dto);
+
+        var result = await controller.EditJugador("user1");
+
+        result.Should().BeOfType<ViewResult>();
+        ((ViewResult)result).Model.Should().Be(dto);
+    }
+
+    [Fact]
+    public async Task POST_EditJugador_Valid_RedirectsWithSuccess()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.UpdateJugadorAsync("user1", It.IsAny<AdminUserEditDto>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await controller.EditJugadorPost("user1", new AdminUserEditDto("NewName", "new@email.com"));
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        ((RedirectToActionResult)result).ActionName.Should().Be("Jugadores");
+        controller.TempData[TempDataKeys.Success].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task POST_DeactivateJugador_Success_RedirectsWithSuccess()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.DeactivateJugadorAsync("user1")).Returns(Task.CompletedTask);
+
+        var result = await controller.DeactivateJugador("user1");
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        ((RedirectToActionResult)result).ActionName.Should().Be("Jugadores");
+        controller.TempData[TempDataKeys.Success].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task POST_ReactivateJugador_Success_RedirectsWithSuccess()
+    {
+        var (controller, adminSvc) = BuildSut();
+        adminSvc.Setup(s => s.ReactivateUserAsync("user1")).Returns(Task.CompletedTask);
+
+        var result = await controller.ReactivateJugador("user1");
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        ((RedirectToActionResult)result).ActionName.Should().Be("Jugadores");
+        controller.TempData[TempDataKeys.Success].Should().NotBeNull();
+    }
+
+    // ─── Configuracion ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GET_Configuracion_ReturnsViewWithModel()
+    {
+        var (controller, adminSvc) = BuildSut();
+        var config = new ConfiguracionGlobal { Id = 1, PorcentajePlataforma = 10 };
+        adminSvc.Setup(s => s.GetConfiguracionAsync()).ReturnsAsync(config);
+
+        var result = await controller.Configuracion();
+
+        result.Should().BeOfType<ViewResult>();
+        ((ViewResult)result).Model.Should().Be(config);
+    }
+
+    [Fact]
+    public async Task POST_Configuracion_Valid_RedirectsWithSuccess()
+    {
+        var (controller, adminSvc) = BuildSut();
+        var config = new ConfiguracionGlobal { Id = 1, PorcentajePlataforma = 10, PorcentajeOrganizadorMin = 5, PorcentajeOrganizadorMax = 30, MontoInscripcionMinimo = 500 };
+        adminSvc.Setup(s => s.UpdateConfiguracionAsync(config)).Returns(Task.CompletedTask);
+
+        var result = await controller.ConfiguracionPost(config);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        ((RedirectToActionResult)result).ActionName.Should().Be("Configuracion");
+        controller.TempData[TempDataKeys.Success].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task POST_Configuracion_ArgumentException_AddsModelError_AndReturnsView()
+    {
+        var (controller, adminSvc) = BuildSut();
+        var config = new ConfiguracionGlobal { Id = 1, PorcentajePlataforma = 60 };
+        adminSvc.Setup(s => s.UpdateConfiguracionAsync(config))
+            .ThrowsAsync(new ArgumentException("Porcentaje inválido."));
+
+        var result = await controller.ConfiguracionPost(config);
+
+        result.Should().BeOfType<ViewResult>();
+        controller.ModelState.IsValid.Should().BeFalse();
+    }
+}

--- a/BanterBotSports.Tests/Unit/AdminServiceTests.cs
+++ b/BanterBotSports.Tests/Unit/AdminServiceTests.cs
@@ -1,0 +1,307 @@
+using BanterBotSports.BL;
+using BanterBotSports.BL.Models;
+using BanterBotSports.BL.Services;
+using BanterBotSports.DAL;
+using BanterBotSports.Entities;
+using BanterBotSports.Entities.Enums;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace BanterBotSports.Tests.Unit;
+
+/// <summary>
+/// Unit tests for AdminService: configuration management and user (organizer/player) operations.
+/// Uses EF InMemory provider and a mocked UserManager.
+/// </summary>
+public class AdminServiceTests
+{
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static AppDbContext BuildDb(string dbName)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        return new AppDbContext(opts);
+    }
+
+    private static Mock<UserManager<AppUser>> BuildUserManagerMock()
+    {
+        var store = new Mock<IUserStore<AppUser>>();
+        return new Mock<UserManager<AppUser>>(
+            store.Object, null!, null!, null!, null!, null!, null!, null!, null!);
+    }
+
+    private static AppUser BuildUser(string id, string? phone = null, string? nombre = null, DateTimeOffset? lockoutEnd = null)
+        => new() { Id = id, UserName = phone ?? id, PhoneNumber = phone, NombreDisplay = nombre, LockoutEnd = lockoutEnd };
+
+    private static Torneo BuildTorneo(int id, string orgId, EstadoTorneo estado = EstadoTorneo.Activo)
+        => new() { Id = id, Nombre = $"Torneo {id}", OrganizadorId = orgId, Estado = estado };
+
+    // ─── GetConfiguracion ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetConfiguracion_ExistingRow_ReturnsIt()
+    {
+        await using var db = BuildDb(nameof(GetConfiguracion_ExistingRow_ReturnsIt));
+        var config = new ConfiguracionGlobal { Id = 1, PorcentajePlataforma = 15, PorcentajeOrganizadorMin = 8, PorcentajeOrganizadorMax = 25, MontoInscripcionMinimo = 300 };
+        db.ConfiguracionGlobal.Add(config);
+        await db.SaveChangesAsync();
+
+        var sut = new AdminService(db, BuildUserManagerMock().Object);
+        var result = await sut.GetConfiguracionAsync();
+
+        result.PorcentajePlataforma.Should().Be(15);
+        result.MontoInscripcionMinimo.Should().Be(300);
+    }
+
+    [Fact]
+    public async Task GetConfiguracion_EmptyDb_ReturnsDefaults()
+    {
+        await using var db = BuildDb(nameof(GetConfiguracion_EmptyDb_ReturnsDefaults));
+        var sut = new AdminService(db, BuildUserManagerMock().Object);
+        var result = await sut.GetConfiguracionAsync();
+
+        result.Id.Should().Be(1);
+        result.PorcentajePlataforma.Should().Be(10);
+        result.PorcentajeOrganizadorMin.Should().Be(5);
+        result.PorcentajeOrganizadorMax.Should().Be(30);
+        result.MontoInscripcionMinimo.Should().Be(500);
+    }
+
+    // ─── UpdateConfiguracion ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateConfiguracion_ValidValues_Persists()
+    {
+        await using var db = BuildDb(nameof(UpdateConfiguracion_ValidValues_Persists));
+        db.ConfiguracionGlobal.Add(new ConfiguracionGlobal { Id = 1, PorcentajePlataforma = 10, PorcentajeOrganizadorMin = 5, PorcentajeOrganizadorMax = 30, MontoInscripcionMinimo = 500 });
+        await db.SaveChangesAsync();
+
+        var sut = new AdminService(db, BuildUserManagerMock().Object);
+        var updated = new ConfiguracionGlobal { Id = 1, PorcentajePlataforma = 12, PorcentajeOrganizadorMin = 6, PorcentajeOrganizadorMax = 28, MontoInscripcionMinimo = 600 };
+        await sut.UpdateConfiguracionAsync(updated);
+
+        var saved = await db.ConfiguracionGlobal.FindAsync(1);
+        saved!.PorcentajePlataforma.Should().Be(12);
+        saved.MontoInscripcionMinimo.Should().Be(600);
+    }
+
+    [Fact]
+    public async Task UpdateConfiguracion_OrgMinGreaterThanOrgMax_ThrowsArgumentException()
+    {
+        await using var db = BuildDb(nameof(UpdateConfiguracion_OrgMinGreaterThanOrgMax_ThrowsArgumentException));
+        var sut = new AdminService(db, BuildUserManagerMock().Object);
+        var bad = new ConfiguracionGlobal { Id = 1, PorcentajePlataforma = 10, PorcentajeOrganizadorMin = 40, PorcentajeOrganizadorMax = 20, MontoInscripcionMinimo = 500 };
+
+        await sut.Invoking(s => s.UpdateConfiguracionAsync(bad))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task UpdateConfiguracion_PorcentajePlataformaOver50_ThrowsArgumentException()
+    {
+        await using var db = BuildDb(nameof(UpdateConfiguracion_PorcentajePlataformaOver50_ThrowsArgumentException));
+        var sut = new AdminService(db, BuildUserManagerMock().Object);
+        var bad = new ConfiguracionGlobal { Id = 1, PorcentajePlataforma = 51, PorcentajeOrganizadorMin = 5, PorcentajeOrganizadorMax = 30, MontoInscripcionMinimo = 500 };
+
+        await sut.Invoking(s => s.UpdateConfiguracionAsync(bad))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task UpdateConfiguracion_AnyValueZeroOrNegative_ThrowsArgumentException()
+    {
+        await using var db = BuildDb(nameof(UpdateConfiguracion_AnyValueZeroOrNegative_ThrowsArgumentException));
+        var sut = new AdminService(db, BuildUserManagerMock().Object);
+        var bad = new ConfiguracionGlobal { Id = 1, PorcentajePlataforma = 0, PorcentajeOrganizadorMin = 5, PorcentajeOrganizadorMax = 30, MontoInscripcionMinimo = 500 };
+
+        await sut.Invoking(s => s.UpdateConfiguracionAsync(bad))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ─── GetOrganizadores ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetOrganizadores_OnlyUsersWithTorneos()
+    {
+        await using var db = BuildDb(nameof(GetOrganizadores_OnlyUsersWithTorneos));
+        var userWithTorneo = BuildUser("org1", "5551111111");
+        var userWithoutTorneo = BuildUser("org2", "5552222222");
+        db.Users.AddRange(userWithTorneo, userWithoutTorneo);
+        db.Torneos.Add(BuildTorneo(1, "org1"));
+        await db.SaveChangesAsync();
+
+        var sut = new AdminService(db, BuildUserManagerMock().Object);
+        var result = await sut.GetOrganizadoresAsync();
+
+        result.Should().HaveCount(1);
+        result[0].Id.Should().Be("org1");
+    }
+
+    // ─── UpdateOrganizador ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateOrganizador_SavesNombreDisplayAndEmail()
+    {
+        await using var db = BuildDb(nameof(UpdateOrganizador_SavesNombreDisplayAndEmail));
+        var um = BuildUserManagerMock();
+        var user = BuildUser("org1", "5551111111", "OldName");
+        um.Setup(m => m.FindByIdAsync("org1")).ReturnsAsync(user);
+        um.Setup(m => m.UpdateAsync(It.IsAny<AppUser>())).ReturnsAsync(IdentityResult.Success);
+
+        var sut = new AdminService(db, um.Object);
+        await sut.UpdateOrganizadorAsync("org1", new AdminUserEditDto("NewName", "new@email.com"));
+
+        user.NombreDisplay.Should().Be("NewName");
+        user.Email.Should().Be("new@email.com");
+        um.Verify(m => m.UpdateAsync(user), Times.Once);
+    }
+
+    // ─── DeactivateOrganizador ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeactivateOrganizador_NoActiveTorneos_SetsLockoutMax()
+    {
+        await using var db = BuildDb(nameof(DeactivateOrganizador_NoActiveTorneos_SetsLockoutMax));
+        db.Torneos.Add(BuildTorneo(1, "org1", EstadoTorneo.Finalizado));
+        await db.SaveChangesAsync();
+
+        var um = BuildUserManagerMock();
+        var user = BuildUser("org1");
+        um.Setup(m => m.FindByIdAsync("org1")).ReturnsAsync(user);
+        um.Setup(m => m.UpdateAsync(It.IsAny<AppUser>())).ReturnsAsync(IdentityResult.Success);
+
+        var sut = new AdminService(db, um.Object);
+        await sut.DeactivateOrganizadorAsync("org1");
+
+        user.LockoutEnd.Should().Be(DateTimeOffset.MaxValue);
+        user.LockoutEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeactivateOrganizador_WithActiveTorneo_ThrowsInvalidOperation()
+    {
+        await using var db = BuildDb(nameof(DeactivateOrganizador_WithActiveTorneo_ThrowsInvalidOperation));
+        db.Torneos.Add(BuildTorneo(1, "org1", EstadoTorneo.Activo));
+        await db.SaveChangesAsync();
+
+        var sut = new AdminService(db, BuildUserManagerMock().Object);
+
+        await sut.Invoking(s => s.DeactivateOrganizadorAsync("org1"))
+            .Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task DeactivateOrganizador_WithPendienteTorneo_ThrowsInvalidOperation()
+    {
+        await using var db = BuildDb(nameof(DeactivateOrganizador_WithPendienteTorneo_ThrowsInvalidOperation));
+        db.Torneos.Add(BuildTorneo(1, "org1", EstadoTorneo.Pendiente));
+        await db.SaveChangesAsync();
+
+        var sut = new AdminService(db, BuildUserManagerMock().Object);
+
+        await sut.Invoking(s => s.DeactivateOrganizadorAsync("org1"))
+            .Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // ─── ReactivateUser ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ReactivateUser_ClearsLockoutEnd()
+    {
+        await using var db = BuildDb(nameof(ReactivateUser_ClearsLockoutEnd));
+        var um = BuildUserManagerMock();
+        var user = BuildUser("user1", lockoutEnd: DateTimeOffset.MaxValue);
+        um.Setup(m => m.FindByIdAsync("user1")).ReturnsAsync(user);
+        um.Setup(m => m.UpdateAsync(It.IsAny<AppUser>())).ReturnsAsync(IdentityResult.Success);
+
+        var sut = new AdminService(db, um.Object);
+        await sut.ReactivateUserAsync("user1");
+
+        user.LockoutEnd.Should().BeNull();
+        um.Verify(m => m.UpdateAsync(user), Times.Once);
+    }
+
+    // ─── GetJugadores ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetJugadores_ExcludesAdminRoleUsers()
+    {
+        await using var db = BuildDb(nameof(GetJugadores_ExcludesAdminRoleUsers));
+        var adminUser = BuildUser("admin1", "5550000000");
+        var jugadorUser = BuildUser("jug1", "5551111111");
+        db.Users.AddRange(adminUser, jugadorUser);
+        await db.SaveChangesAsync();
+
+        var um = BuildUserManagerMock();
+        um.Setup(m => m.GetUsersInRoleAsync(AppRoles.Admin))
+            .ReturnsAsync(new List<AppUser> { adminUser });
+
+        var sut = new AdminService(db, um.Object);
+        var result = await sut.GetJugadoresAsync();
+
+        result.Should().HaveCount(1);
+        result[0].Id.Should().Be("jug1");
+    }
+
+    [Fact]
+    public async Task GetJugadores_SearchByPhone_FiltersCorrectly()
+    {
+        await using var db = BuildDb(nameof(GetJugadores_SearchByPhone_FiltersCorrectly));
+        var user1 = BuildUser("jug1", "5551234567");
+        var user2 = BuildUser("jug2", "5559876543");
+        db.Users.AddRange(user1, user2);
+        await db.SaveChangesAsync();
+
+        var um = BuildUserManagerMock();
+        um.Setup(m => m.GetUsersInRoleAsync(AppRoles.Admin))
+            .ReturnsAsync(new List<AppUser>());
+
+        var sut = new AdminService(db, um.Object);
+        var result = await sut.GetJugadoresAsync("1234");
+
+        result.Should().HaveCount(1);
+        result[0].Phone.Should().Be("5551234567");
+    }
+
+    [Fact]
+    public async Task GetJugadores_SearchByNombreDisplay_CaseInsensitive()
+    {
+        await using var db = BuildDb(nameof(GetJugadores_SearchByNombreDisplay_CaseInsensitive));
+        var user1 = BuildUser("jug1", "5551111111", "Carlos Perez");
+        var user2 = BuildUser("jug2", "5552222222", "Ana Lopez");
+        db.Users.AddRange(user1, user2);
+        await db.SaveChangesAsync();
+
+        var um = BuildUserManagerMock();
+        um.Setup(m => m.GetUsersInRoleAsync(AppRoles.Admin))
+            .ReturnsAsync(new List<AppUser>());
+
+        var sut = new AdminService(db, um.Object);
+        var result = await sut.GetJugadoresAsync("carlos");
+
+        result.Should().HaveCount(1);
+        result[0].NombreDisplay.Should().Be("Carlos Perez");
+    }
+
+    // ─── DeactivateJugador ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeactivateJugador_SetsLockoutMax()
+    {
+        await using var db = BuildDb(nameof(DeactivateJugador_SetsLockoutMax));
+        var um = BuildUserManagerMock();
+        var user = BuildUser("jug1");
+        um.Setup(m => m.FindByIdAsync("jug1")).ReturnsAsync(user);
+        um.Setup(m => m.UpdateAsync(It.IsAny<AppUser>())).ReturnsAsync(IdentityResult.Success);
+
+        var sut = new AdminService(db, um.Object);
+        await sut.DeactivateJugadorAsync("jug1");
+
+        user.LockoutEnd.Should().Be(DateTimeOffset.MaxValue);
+        user.LockoutEnabled.Should().BeTrue();
+    }
+}

--- a/BanterBotSports.Web/Controllers/AdminController.cs
+++ b/BanterBotSports.Web/Controllers/AdminController.cs
@@ -1,0 +1,162 @@
+using BanterBotSports.BL;
+using BanterBotSports.BL.Models;
+using BanterBotSports.BL.Services.Interfaces;
+using BanterBotSports.Entities;
+using BanterBotSports.Web.Infrastructure;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BanterBotSports.Web.Controllers;
+
+/// <summary>
+/// Administrative panel: platform configuration and user management (organizers + players).
+/// Restricted to Admin role.
+/// </summary>
+[Authorize(Roles = AppRoles.Admin)]
+[Route("admin")]
+public class AdminController : Controller
+{
+    private readonly IAdminService _adminService;
+
+    public AdminController(IAdminService adminService)
+    {
+        ArgumentNullException.ThrowIfNull(adminService);
+        _adminService = adminService;
+    }
+
+    // ─── Index ───────────────────────────────────────────────────────────────
+
+    [HttpGet("")]
+    public IActionResult Index() => View();
+
+    // ─── Organizadores ───────────────────────────────────────────────────────
+
+    [HttpGet("organizadores")]
+    public async Task<IActionResult> Organizadores()
+    {
+        var list = await _adminService.GetOrganizadoresAsync();
+        return View(list);
+    }
+
+    [HttpGet("organizadores/{userId}/edit")]
+    public async Task<IActionResult> EditOrganizador(string userId)
+    {
+        var dto = await _adminService.GetOrganizadorAsync(userId);
+        if (dto is null) return NotFound();
+        return View(dto);
+    }
+
+    [HttpPost("organizadores/{userId}/edit")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> EditOrganizadorPost(string userId, AdminUserEditDto dto)
+    {
+        if (!ModelState.IsValid)
+            return RedirectToAction(nameof(EditOrganizador), new { userId });
+
+        await _adminService.UpdateOrganizadorAsync(userId, dto);
+        TempData[TempDataKeys.Success] = "Organizador actualizado correctamente.";
+        return RedirectToAction(nameof(Organizadores));
+    }
+
+    [HttpPost("organizadores/{userId}/deactivate")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeactivateOrganizador(string userId)
+    {
+        try
+        {
+            await _adminService.DeactivateOrganizadorAsync(userId);
+            TempData[TempDataKeys.Success] = "Organizador desactivado correctamente.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData[TempDataKeys.Error] = ex.Message;
+        }
+        return RedirectToAction(nameof(Organizadores));
+    }
+
+    [HttpPost("organizadores/{userId}/reactivate")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ReactivateOrganizador(string userId)
+    {
+        await _adminService.ReactivateUserAsync(userId);
+        TempData[TempDataKeys.Success] = "Organizador reactivado correctamente.";
+        return RedirectToAction(nameof(Organizadores));
+    }
+
+    // ─── Jugadores ───────────────────────────────────────────────────────────
+
+    [HttpGet("jugadores")]
+    public async Task<IActionResult> Jugadores(string? search)
+    {
+        var list = await _adminService.GetJugadoresAsync(search);
+        ViewData["Search"] = search;
+        return View(list);
+    }
+
+    [HttpGet("jugadores/{userId}/edit")]
+    public async Task<IActionResult> EditJugador(string userId)
+    {
+        var dto = await _adminService.GetJugadorAsync(userId);
+        if (dto is null) return NotFound();
+        return View(dto);
+    }
+
+    [HttpPost("jugadores/{userId}/edit")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> EditJugadorPost(string userId, AdminUserEditDto dto)
+    {
+        if (!ModelState.IsValid)
+            return RedirectToAction(nameof(EditJugador), new { userId });
+
+        await _adminService.UpdateJugadorAsync(userId, dto);
+        TempData[TempDataKeys.Success] = "Jugador actualizado correctamente.";
+        return RedirectToAction(nameof(Jugadores));
+    }
+
+    [HttpPost("jugadores/{userId}/deactivate")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeactivateJugador(string userId)
+    {
+        await _adminService.DeactivateJugadorAsync(userId);
+        TempData[TempDataKeys.Success] = "Jugador desactivado correctamente.";
+        return RedirectToAction(nameof(Jugadores));
+    }
+
+    [HttpPost("jugadores/{userId}/reactivate")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ReactivateJugador(string userId)
+    {
+        await _adminService.ReactivateUserAsync(userId);
+        TempData[TempDataKeys.Success] = "Jugador reactivado correctamente.";
+        return RedirectToAction(nameof(Jugadores));
+    }
+
+    // ─── Configuracion ───────────────────────────────────────────────────────
+
+    [HttpGet("configuracion")]
+    public async Task<IActionResult> Configuracion()
+    {
+        var config = await _adminService.GetConfiguracionAsync();
+        return View(config);
+    }
+
+    [HttpPost("configuracion")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ConfiguracionPost(ConfiguracionGlobal config)
+    {
+        if (!ModelState.IsValid)
+            return View(config);
+
+        try
+        {
+            await _adminService.UpdateConfiguracionAsync(config);
+            TempData[TempDataKeys.Success] = "Configuración guardada correctamente.";
+            return RedirectToAction(nameof(Configuracion));
+        }
+        catch (ArgumentException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return View(config);
+        }
+    }
+}

--- a/BanterBotSports.Web/Program.cs
+++ b/BanterBotSports.Web/Program.cs
@@ -2,6 +2,7 @@ using BanterBotSports.BanterAI;
 using BanterBotSports.BL.Services;
 using BanterBotSports.BL.Services.Hosted;
 using BanterBotSports.BL.Services.Interfaces;
+using BanterBotSports.Entities;
 using BanterBotSports.DAL;
 using BanterBotSports.DAL.Repositories;
 using BanterBotSports.DAL.Repositories.Interfaces;
@@ -65,6 +66,7 @@ builder.Services.AddScoped<IPartidoService, PartidoService>();
 builder.Services.AddScoped<IJornadaService, JornadaService>();
 builder.Services.AddScoped<ITelegramVinculacionService, TelegramVinculacionService>();
 builder.Services.AddScoped<IChatService, ChatService>();
+builder.Services.AddScoped<IAdminService, AdminService>();
 
 // ─── In-Memory Cache (used by ApiFootballSyncService for search results) ─────
 builder.Services.AddMemoryCache();

--- a/BanterBotSports.Web/Program.cs
+++ b/BanterBotSports.Web/Program.cs
@@ -145,6 +145,32 @@ using (var scope = app.Services.CreateScope())
     await db.Database.MigrateAsync();
 }
 
+// ─── Admin provisioning ──────────────────────────────────────────────────────
+var seedAdminArg = args.SkipWhile(a => a != "--seed-admin").Skip(1).FirstOrDefault();
+if (seedAdminArg is not null)
+{
+    using var scope = app.Services.CreateScope();
+    var userManager = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
+    var user = await userManager.FindByNameAsync(seedAdminArg);
+    if (user is null)
+    {
+        app.Logger.LogError("--seed-admin: no user found with phone/username '{Phone}'", seedAdminArg);
+        Environment.Exit(1);
+    }
+    await userManager.AddToRoleAsync(user, "Admin");
+    app.Logger.LogInformation("--seed-admin: user '{Phone}' assigned Admin role.", seedAdminArg);
+    Environment.Exit(0);
+}
+
+// ─── Warn if no admin user exists ────────────────────────────────────────────
+using (var warnScope = app.Services.CreateScope())
+{
+    var userManager = warnScope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
+    var admins = await userManager.GetUsersInRoleAsync("Admin");
+    if (admins.Count == 0)
+        app.Logger.LogWarning("No Admin-role users exist. Run: dotnet run -- --seed-admin {phone}");
+}
+
 // ─── Middleware pipeline ─────────────────────────────────────────────────────
 // UseExceptionHandler is always active so DB/internal errors never expose stack
 // traces to the browser — not even in Development when run outside a debugger.

--- a/BanterBotSports.Web/Views/Admin/Configuracion.cshtml
+++ b/BanterBotSports.Web/Views/Admin/Configuracion.cshtml
@@ -1,0 +1,71 @@
+@model BanterBotSports.Entities.ConfiguracionGlobal
+@{
+    ViewData["Title"] = "Configuración Global";
+}
+
+<div class="mb-6">
+    <a asp-action="Index" class="text-on-surface-variant hover:text-on-surface text-sm flex items-center gap-1 mb-2 transition-colors">
+        <span class="material-symbols-outlined text-sm">arrow_back</span> Panel Admin
+    </a>
+    <h1 class="text-2xl font-black tracking-tighter text-on-surface uppercase">Configuración Global</h1>
+    <p class="text-on-surface-variant text-sm mt-1">Porcentajes de plataforma y montos mínimos de inscripción.</p>
+</div>
+
+<div class="max-w-xl">
+    <div class="bg-surface-container-low rounded-2xl p-6 border border-outline/10">
+        <form asp-action="ConfiguracionPost" method="post" class="space-y-5">
+            @Html.AntiForgeryToken()
+
+            @if (!ViewData.ModelState.IsValid)
+            {
+                <div asp-validation-summary="All"
+                     class="p-4 bg-error/10 rounded-xl border-l-4 border-error text-error text-sm"></div>
+            }
+
+            <input type="hidden" name="Id" value="@Model.Id" />
+
+            <div>
+                <label class="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-1">
+                    Porcentaje Plataforma (%)
+                </label>
+                <input type="number" name="PorcentajePlataforma" value="@Model.PorcentajePlataforma"
+                       step="0.01" min="0.01" max="50"
+                       class="w-full px-4 py-2.5 bg-surface-container rounded-xl border border-outline/20 text-on-surface focus:outline-none focus:border-primary transition-colors" />
+                <p class="text-xs text-on-surface-variant mt-1">Máximo: 50%</p>
+            </div>
+
+            <div>
+                <label class="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-1">
+                    Porcentaje Organizador Mínimo (%)
+                </label>
+                <input type="number" name="PorcentajeOrganizadorMin" value="@Model.PorcentajeOrganizadorMin"
+                       step="0.01" min="0.01"
+                       class="w-full px-4 py-2.5 bg-surface-container rounded-xl border border-outline/20 text-on-surface focus:outline-none focus:border-primary transition-colors" />
+            </div>
+
+            <div>
+                <label class="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-1">
+                    Porcentaje Organizador Máximo (%)
+                </label>
+                <input type="number" name="PorcentajeOrganizadorMax" value="@Model.PorcentajeOrganizadorMax"
+                       step="0.01" min="0.01"
+                       class="w-full px-4 py-2.5 bg-surface-container rounded-xl border border-outline/20 text-on-surface focus:outline-none focus:border-primary transition-colors" />
+            </div>
+
+            <div>
+                <label class="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-1">
+                    Monto Inscripción Mínimo ($)
+                </label>
+                <input type="number" name="MontoInscripcionMinimo" value="@Model.MontoInscripcionMinimo"
+                       step="0.01" min="0.01"
+                       class="w-full px-4 py-2.5 bg-surface-container rounded-xl border border-outline/20 text-on-surface focus:outline-none focus:border-primary transition-colors" />
+            </div>
+
+            <button type="submit"
+                    class="w-full py-3 bg-gradient-to-r from-primary to-primary-container text-on-primary-container font-bold rounded-xl active:scale-95 transition-all flex items-center justify-center gap-2">
+                <span class="material-symbols-outlined text-sm">save</span>
+                Guardar configuración
+            </button>
+        </form>
+    </div>
+</div>

--- a/BanterBotSports.Web/Views/Admin/EditJugador.cshtml
+++ b/BanterBotSports.Web/Views/Admin/EditJugador.cshtml
@@ -1,0 +1,95 @@
+@model BanterBotSports.BL.Models.AdminUserDto
+@{
+    ViewData["Title"] = "Editar Jugador";
+}
+
+<div class="mb-6">
+    <a asp-action="Jugadores" class="text-on-surface-variant hover:text-on-surface text-sm flex items-center gap-1 mb-2 transition-colors">
+        <span class="material-symbols-outlined text-sm">arrow_back</span> Jugadores
+    </a>
+    <h1 class="text-2xl font-black tracking-tighter text-on-surface uppercase">Editar Jugador</h1>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+    @* Read-only info card *@
+    <div class="bg-surface-container-low rounded-2xl p-6 border border-outline/10">
+        <h2 class="text-sm font-bold text-on-surface-variant uppercase tracking-widest mb-4">Información</h2>
+        <dl class="space-y-3">
+            <div>
+                <dt class="text-xs text-on-surface-variant">Teléfono</dt>
+                <dd class="font-medium text-on-surface">@(Model.Phone ?? "-")</dd>
+            </div>
+            <div>
+                <dt class="text-xs text-on-surface-variant">Torneos participados</dt>
+                <dd class="font-bold text-secondary">@Model.TorneosParticipados</dd>
+            </div>
+            <div>
+                <dt class="text-xs text-on-surface-variant">Estado</dt>
+                <dd>
+                    @if (Model.IsActive)
+                    {
+                        <span class="px-2 py-1 bg-secondary/10 text-secondary text-xs font-bold rounded-full">Activo</span>
+                    }
+                    else
+                    {
+                        <span class="px-2 py-1 bg-error/10 text-error text-xs font-bold rounded-full">Inactivo</span>
+                    }
+                </dd>
+            </div>
+        </dl>
+    </div>
+
+    @* Edit form *@
+    <div class="bg-surface-container-low rounded-2xl p-6 border border-outline/10">
+        <h2 class="text-sm font-bold text-on-surface-variant uppercase tracking-widest mb-4">Editar datos</h2>
+        <form asp-action="EditJugadorPost" asp-route-userId="@Model.Id" method="post" class="space-y-4">
+            @Html.AntiForgeryToken()
+            <div>
+                <label class="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-1">Nombre de display</label>
+                <input type="text" name="NombreDisplay" value="@Model.NombreDisplay"
+                       class="w-full px-4 py-2.5 bg-surface-container rounded-xl border border-outline/20 text-on-surface focus:outline-none focus:border-primary transition-colors" />
+            </div>
+            <div>
+                <label class="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-1">Email</label>
+                <input type="email" name="Email" value="@Model.Email"
+                       class="w-full px-4 py-2.5 bg-surface-container rounded-xl border border-outline/20 text-on-surface focus:outline-none focus:border-primary transition-colors" />
+            </div>
+            <button type="submit"
+                    class="w-full py-3 bg-gradient-to-r from-primary to-primary-container text-on-primary-container font-bold rounded-xl active:scale-95 transition-all">
+                Guardar cambios
+            </button>
+        </form>
+    </div>
+
+</div>
+
+@* Deactivate / Reactivate *@
+<div class="mt-6 bg-surface-container-low rounded-2xl p-6 border border-outline/10">
+    <h2 class="text-sm font-bold text-on-surface-variant uppercase tracking-widest mb-4">Estado de la cuenta</h2>
+    @if (!Model.IsActive)
+    {
+        <p class="text-error text-sm mb-4 flex items-center gap-2">
+            <span class="material-symbols-outlined text-sm">warning</span>
+            Esta cuenta está desactivada.
+        </p>
+        <form asp-action="ReactivateJugador" asp-route-userId="@Model.Id" method="post" class="inline">
+            @Html.AntiForgeryToken()
+            <button type="submit"
+                    class="px-6 py-2.5 bg-secondary/10 text-secondary font-bold rounded-xl hover:bg-secondary/20 transition-colors">
+                Reactivar cuenta
+            </button>
+        </form>
+    }
+    else
+    {
+        <form asp-action="DeactivateJugador" asp-route-userId="@Model.Id" method="post" class="inline">
+            @Html.AntiForgeryToken()
+            <button type="submit"
+                    class="px-6 py-2.5 bg-error/10 text-error font-bold rounded-xl hover:bg-error/20 transition-colors"
+                    onclick="return confirm('¿Desactivar este jugador?')">
+                Desactivar cuenta
+            </button>
+        </form>
+    }
+</div>

--- a/BanterBotSports.Web/Views/Admin/EditOrganizador.cshtml
+++ b/BanterBotSports.Web/Views/Admin/EditOrganizador.cshtml
@@ -1,0 +1,95 @@
+@model BanterBotSports.BL.Models.AdminUserDto
+@{
+    ViewData["Title"] = "Editar Organizador";
+}
+
+<div class="mb-6">
+    <a asp-action="Organizadores" class="text-on-surface-variant hover:text-on-surface text-sm flex items-center gap-1 mb-2 transition-colors">
+        <span class="material-symbols-outlined text-sm">arrow_back</span> Organizadores
+    </a>
+    <h1 class="text-2xl font-black tracking-tighter text-on-surface uppercase">Editar Organizador</h1>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+    @* Read-only info card *@
+    <div class="bg-surface-container-low rounded-2xl p-6 border border-outline/10">
+        <h2 class="text-sm font-bold text-on-surface-variant uppercase tracking-widest mb-4">Información</h2>
+        <dl class="space-y-3">
+            <div>
+                <dt class="text-xs text-on-surface-variant">Teléfono</dt>
+                <dd class="font-medium text-on-surface">@(Model.Phone ?? "-")</dd>
+            </div>
+            <div>
+                <dt class="text-xs text-on-surface-variant">Torneos organizados</dt>
+                <dd class="font-bold text-primary">@Model.TorneosOrganizados</dd>
+            </div>
+            <div>
+                <dt class="text-xs text-on-surface-variant">Estado</dt>
+                <dd>
+                    @if (Model.IsActive)
+                    {
+                        <span class="px-2 py-1 bg-secondary/10 text-secondary text-xs font-bold rounded-full">Activo</span>
+                    }
+                    else
+                    {
+                        <span class="px-2 py-1 bg-error/10 text-error text-xs font-bold rounded-full">Inactivo</span>
+                    }
+                </dd>
+            </div>
+        </dl>
+    </div>
+
+    @* Edit form *@
+    <div class="bg-surface-container-low rounded-2xl p-6 border border-outline/10">
+        <h2 class="text-sm font-bold text-on-surface-variant uppercase tracking-widest mb-4">Editar datos</h2>
+        <form asp-action="EditOrganizadorPost" asp-route-userId="@Model.Id" method="post" class="space-y-4">
+            @Html.AntiForgeryToken()
+            <div>
+                <label class="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-1">Nombre de display</label>
+                <input type="text" name="NombreDisplay" value="@Model.NombreDisplay"
+                       class="w-full px-4 py-2.5 bg-surface-container rounded-xl border border-outline/20 text-on-surface focus:outline-none focus:border-primary transition-colors" />
+            </div>
+            <div>
+                <label class="block text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-1">Email</label>
+                <input type="email" name="Email" value="@Model.Email"
+                       class="w-full px-4 py-2.5 bg-surface-container rounded-xl border border-outline/20 text-on-surface focus:outline-none focus:border-primary transition-colors" />
+            </div>
+            <button type="submit"
+                    class="w-full py-3 bg-gradient-to-r from-primary to-primary-container text-on-primary-container font-bold rounded-xl active:scale-95 transition-all">
+                Guardar cambios
+            </button>
+        </form>
+    </div>
+
+</div>
+
+@* Deactivate / Reactivate *@
+<div class="mt-6 bg-surface-container-low rounded-2xl p-6 border border-outline/10">
+    <h2 class="text-sm font-bold text-on-surface-variant uppercase tracking-widest mb-4">Estado de la cuenta</h2>
+    @if (!Model.IsActive)
+    {
+        <p class="text-error text-sm mb-4 flex items-center gap-2">
+            <span class="material-symbols-outlined text-sm">warning</span>
+            Esta cuenta está desactivada.
+        </p>
+        <form asp-action="ReactivateOrganizador" asp-route-userId="@Model.Id" method="post" class="inline">
+            @Html.AntiForgeryToken()
+            <button type="submit"
+                    class="px-6 py-2.5 bg-secondary/10 text-secondary font-bold rounded-xl hover:bg-secondary/20 transition-colors">
+                Reactivar cuenta
+            </button>
+        </form>
+    }
+    else
+    {
+        <form asp-action="DeactivateOrganizador" asp-route-userId="@Model.Id" method="post" class="inline">
+            @Html.AntiForgeryToken()
+            <button type="submit"
+                    class="px-6 py-2.5 bg-error/10 text-error font-bold rounded-xl hover:bg-error/20 transition-colors"
+                    onclick="return confirm('¿Desactivar este organizador?')">
+                Desactivar cuenta
+            </button>
+        </form>
+    }
+</div>

--- a/BanterBotSports.Web/Views/Admin/Index.cshtml
+++ b/BanterBotSports.Web/Views/Admin/Index.cshtml
@@ -1,0 +1,56 @@
+@{
+    ViewData["Title"] = "Panel de Administración";
+}
+
+<div class="mb-8">
+    <h1 class="text-3xl font-black tracking-tighter text-on-surface uppercase mb-2">
+        Panel de <span class="text-primary">Administración</span>
+    </h1>
+    <p class="text-on-surface-variant text-sm">Gestioná usuarios y la configuración global de la plataforma.</p>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+
+    <a asp-action="Organizadores"
+       class="group flex flex-col gap-4 p-6 bg-surface-container-low rounded-2xl border border-outline/10 hover:border-primary/40 hover:bg-surface-container transition-all">
+        <div class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
+            <span class="material-symbols-outlined text-primary text-2xl">manage_accounts</span>
+        </div>
+        <div>
+            <h2 class="font-black text-on-surface text-lg">Organizadores</h2>
+            <p class="text-on-surface-variant text-sm mt-1">Editá, activá o desactivá cuentas de organizadores.</p>
+        </div>
+        <span class="text-primary text-sm font-bold flex items-center gap-1 mt-auto">
+            Gestionar <span class="material-symbols-outlined text-sm">arrow_forward</span>
+        </span>
+    </a>
+
+    <a asp-action="Jugadores"
+       class="group flex flex-col gap-4 p-6 bg-surface-container-low rounded-2xl border border-outline/10 hover:border-primary/40 hover:bg-surface-container transition-all">
+        <div class="w-12 h-12 rounded-xl bg-secondary/10 flex items-center justify-center group-hover:bg-secondary/20 transition-colors">
+            <span class="material-symbols-outlined text-secondary text-2xl">group</span>
+        </div>
+        <div>
+            <h2 class="font-black text-on-surface text-lg">Jugadores</h2>
+            <p class="text-on-surface-variant text-sm mt-1">Buscá y gestioná cuentas de jugadores.</p>
+        </div>
+        <span class="text-secondary text-sm font-bold flex items-center gap-1 mt-auto">
+            Gestionar <span class="material-symbols-outlined text-sm">arrow_forward</span>
+        </span>
+    </a>
+
+    <a asp-action="Configuracion"
+       class="group flex flex-col gap-4 p-6 bg-surface-container-low rounded-2xl border border-outline/10 hover:border-primary/40 hover:bg-surface-container transition-all">
+        <div class="w-12 h-12 rounded-xl bg-tertiary/10 flex items-center justify-center group-hover:bg-tertiary/20 transition-colors">
+            <span class="material-symbols-outlined text-tertiary text-2xl">settings</span>
+        </div>
+        <div>
+            <h2 class="font-black text-on-surface text-lg">Configuración</h2>
+            <p class="text-on-surface-variant text-sm mt-1">Porcentajes de plataforma e inscripción mínima.</p>
+        </div>
+        <span class="text-tertiary text-sm font-bold flex items-center gap-1 mt-auto">
+            Configurar <span class="material-symbols-outlined text-sm">arrow_forward</span>
+        </span>
+    </a>
+
+</div>

--- a/BanterBotSports.Web/Views/Admin/Jugadores.cshtml
+++ b/BanterBotSports.Web/Views/Admin/Jugadores.cshtml
@@ -1,0 +1,106 @@
+@model IReadOnlyList<BanterBotSports.BL.Models.AdminUserDto>
+@{
+    ViewData["Title"] = "Jugadores";
+    var search = ViewData["Search"] as string;
+}
+
+<div class="mb-6 flex items-center justify-between">
+    <div>
+        <a asp-action="Index" class="text-on-surface-variant hover:text-on-surface text-sm flex items-center gap-1 mb-2 transition-colors">
+            <span class="material-symbols-outlined text-sm">arrow_back</span> Panel Admin
+        </a>
+        <h1 class="text-2xl font-black tracking-tighter text-on-surface uppercase">Jugadores</h1>
+    </div>
+</div>
+
+@* Search form *@
+<form asp-action="Jugadores" method="get" class="mb-6 flex gap-3">
+    <input type="text" name="search" value="@search" placeholder="Buscar por teléfono o nombre..."
+           class="flex-1 px-4 py-2.5 bg-surface-container-low rounded-xl border border-outline/20 text-on-surface focus:outline-none focus:border-primary transition-colors" />
+    <button type="submit"
+            class="px-5 py-2.5 bg-primary text-on-primary font-bold rounded-xl hover:opacity-90 transition-opacity flex items-center gap-2">
+        <span class="material-symbols-outlined text-sm">search</span>
+        Buscar
+    </button>
+    @if (!string.IsNullOrWhiteSpace(search))
+    {
+        <a asp-action="Jugadores" class="px-4 py-2.5 bg-surface-container-high text-on-surface-variant font-bold rounded-xl hover:bg-surface-bright transition-colors flex items-center gap-1">
+            <span class="material-symbols-outlined text-sm">close</span>
+        </a>
+    }
+</form>
+
+<div class="bg-surface-container-low rounded-2xl overflow-hidden border border-outline/10">
+    @if (!Model.Any())
+    {
+        <div class="p-8 text-center text-on-surface-variant">
+            <span class="material-symbols-outlined text-4xl mb-2 block">group</span>
+            <p>@(string.IsNullOrWhiteSpace(search) ? "No hay jugadores registrados." : "No se encontraron jugadores.")</p>
+        </div>
+    }
+    else
+    {
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-outline/10 text-on-surface-variant text-xs font-bold uppercase tracking-widest">
+                        <th class="px-4 py-3 text-left">Teléfono</th>
+                        <th class="px-4 py-3 text-left">Nombre</th>
+                        <th class="px-4 py-3 text-left">Email</th>
+                        <th class="px-4 py-3 text-center">Estado</th>
+                        <th class="px-4 py-3 text-center">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var user in Model)
+                    {
+                        <tr class="border-b border-outline/5 hover:bg-surface-container transition-colors">
+                            <td class="px-4 py-3 font-medium text-on-surface">@(user.Phone ?? "-")</td>
+                            <td class="px-4 py-3 text-on-surface">@(user.NombreDisplay ?? "-")</td>
+                            <td class="px-4 py-3 text-on-surface-variant">@(user.Email ?? "-")</td>
+                            <td class="px-4 py-3 text-center">
+                                @if (user.IsActive)
+                                {
+                                    <span class="px-2 py-1 bg-secondary/10 text-secondary text-xs font-bold rounded-full">Activo</span>
+                                }
+                                else
+                                {
+                                    <span class="px-2 py-1 bg-error/10 text-error text-xs font-bold rounded-full">Inactivo</span>
+                                }
+                            </td>
+                            <td class="px-4 py-3">
+                                <div class="flex items-center justify-center gap-2">
+                                    <a asp-action="EditJugador" asp-route-userId="@user.Id"
+                                       class="px-3 py-1.5 bg-primary/10 text-primary text-xs font-bold rounded-lg hover:bg-primary/20 transition-colors">
+                                        Editar
+                                    </a>
+                                    @if (user.IsActive)
+                                    {
+                                        <form asp-action="DeactivateJugador" asp-route-userId="@user.Id" method="post" class="inline">
+                                            @Html.AntiForgeryToken()
+                                            <button type="submit"
+                                                    class="px-3 py-1.5 bg-error/10 text-error text-xs font-bold rounded-lg hover:bg-error/20 transition-colors"
+                                                    onclick="return confirm('¿Desactivar este jugador?')">
+                                                Desactivar
+                                            </button>
+                                        </form>
+                                    }
+                                    else
+                                    {
+                                        <form asp-action="ReactivateJugador" asp-route-userId="@user.Id" method="post" class="inline">
+                                            @Html.AntiForgeryToken()
+                                            <button type="submit"
+                                                    class="px-3 py-1.5 bg-secondary/10 text-secondary text-xs font-bold rounded-lg hover:bg-secondary/20 transition-colors">
+                                                Reactivar
+                                            </button>
+                                        </form>
+                                    }
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</div>

--- a/BanterBotSports.Web/Views/Admin/Organizadores.cshtml
+++ b/BanterBotSports.Web/Views/Admin/Organizadores.cshtml
@@ -1,0 +1,92 @@
+@model IReadOnlyList<BanterBotSports.BL.Models.AdminUserDto>
+@{
+    ViewData["Title"] = "Organizadores";
+}
+
+<div class="mb-6 flex items-center justify-between">
+    <div>
+        <a asp-action="Index" class="text-on-surface-variant hover:text-on-surface text-sm flex items-center gap-1 mb-2 transition-colors">
+            <span class="material-symbols-outlined text-sm">arrow_back</span> Panel Admin
+        </a>
+        <h1 class="text-2xl font-black tracking-tighter text-on-surface uppercase">Organizadores</h1>
+    </div>
+</div>
+
+<div class="bg-surface-container-low rounded-2xl overflow-hidden border border-outline/10">
+    @if (!Model.Any())
+    {
+        <div class="p-8 text-center text-on-surface-variant">
+            <span class="material-symbols-outlined text-4xl mb-2 block">manage_accounts</span>
+            <p>No hay organizadores registrados.</p>
+        </div>
+    }
+    else
+    {
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-outline/10 text-on-surface-variant text-xs font-bold uppercase tracking-widest">
+                        <th class="px-4 py-3 text-left">Teléfono</th>
+                        <th class="px-4 py-3 text-left">Nombre</th>
+                        <th class="px-4 py-3 text-left">Email</th>
+                        <th class="px-4 py-3 text-center">Torneos Org.</th>
+                        <th class="px-4 py-3 text-center">Estado</th>
+                        <th class="px-4 py-3 text-center">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var user in Model)
+                    {
+                        <tr class="border-b border-outline/5 hover:bg-surface-container transition-colors">
+                            <td class="px-4 py-3 font-medium text-on-surface">@(user.Phone ?? "-")</td>
+                            <td class="px-4 py-3 text-on-surface">@(user.NombreDisplay ?? "-")</td>
+                            <td class="px-4 py-3 text-on-surface-variant">@(user.Email ?? "-")</td>
+                            <td class="px-4 py-3 text-center">
+                                <span class="text-primary font-bold">@user.TorneosOrganizados</span>
+                            </td>
+                            <td class="px-4 py-3 text-center">
+                                @if (user.IsActive)
+                                {
+                                    <span class="px-2 py-1 bg-secondary/10 text-secondary text-xs font-bold rounded-full">Activo</span>
+                                }
+                                else
+                                {
+                                    <span class="px-2 py-1 bg-error/10 text-error text-xs font-bold rounded-full">Inactivo</span>
+                                }
+                            </td>
+                            <td class="px-4 py-3">
+                                <div class="flex items-center justify-center gap-2">
+                                    <a asp-action="EditOrganizador" asp-route-userId="@user.Id"
+                                       class="px-3 py-1.5 bg-primary/10 text-primary text-xs font-bold rounded-lg hover:bg-primary/20 transition-colors">
+                                        Editar
+                                    </a>
+                                    @if (user.IsActive)
+                                    {
+                                        <form asp-action="DeactivateOrganizador" asp-route-userId="@user.Id" method="post" class="inline">
+                                            @Html.AntiForgeryToken()
+                                            <button type="submit"
+                                                    class="px-3 py-1.5 bg-error/10 text-error text-xs font-bold rounded-lg hover:bg-error/20 transition-colors"
+                                                    onclick="return confirm('¿Desactivar este organizador?')">
+                                                Desactivar
+                                            </button>
+                                        </form>
+                                    }
+                                    else
+                                    {
+                                        <form asp-action="ReactivateOrganizador" asp-route-userId="@user.Id" method="post" class="inline">
+                                            @Html.AntiForgeryToken()
+                                            <button type="submit"
+                                                    class="px-3 py-1.5 bg-secondary/10 text-secondary text-xs font-bold rounded-lg hover:bg-secondary/20 transition-colors">
+                                                Reactivar
+                                            </button>
+                                        </form>
+                                    }
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</div>

--- a/BanterBotSports.Web/Views/Shared/_Layout.cshtml
+++ b/BanterBotSports.Web/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
 @using BanterBotSports.Web.Infrastructure
+@using BanterBotSports.BL
 @using System.Security.Claims
 <!DOCTYPE html>
 <html lang="es">
@@ -53,6 +54,13 @@
                 <a asp-controller="Torneo" asp-action="Nuevo"
                    class="font-bold tracking-tight text-on-surface/70 hover:text-on-surface transition-colors">
                     Crear Torneo
+                </a>
+            }
+            @if (User.IsInRole(AppRoles.Admin))
+            {
+                <a asp-controller="Admin" asp-action="Index"
+                   class="font-bold tracking-tight text-primary/80 hover:text-primary transition-colors">
+                    Admin
                 </a>
             }
         </div>
@@ -183,6 +191,14 @@
             <span class="material-symbols-outlined">account_circle</span>
             <span class="text-[10px] font-bold uppercase tracking-[0.05em]">Profile</span>
         </a>
+        @if (User.IsInRole(AppRoles.Admin))
+        {
+            <a asp-controller="Admin" asp-action="Index"
+               class="flex flex-col items-center justify-center px-5 py-2 text-primary/80 hover:text-primary transition-all active:scale-95">
+                <span class="material-symbols-outlined">admin_panel_settings</span>
+                <span class="text-[10px] font-bold uppercase tracking-[0.05em]">Admin</span>
+            </a>
+        }
     </nav>
 
     @await RenderSectionAsync("Scripts", required: false)


### PR DESCRIPTION
Closes #46

## Type
- [x] New feature

## Summary
- Agrega el panel de administración completo (`/admin/*`) accesible solo a usuarios con rol `Admin`
- Implementa CRUD de organizadores y jugadores con activación/desactivación de cuentas
- Implementa configuración global de plataforma (`ConfiguracionGlobal`: porcentaje plataforma, rango organizador, monto mínimo de inscripción)

## Changes

| File | Change |
|------|--------|
| `BanterBotSports.Entities/ConfiguracionGlobal.cs` | Nueva entidad singleton |
| `BanterBotSports.DAL/AppDbContext.cs` | DbSet + precision config |
| `BanterBotSports.DAL/Migrations/..._AddConfiguracionGlobalAndRoles.cs` | Tabla ConfiguracionGlobal + seed + roles Admin/Jugador |
| `BanterBotSports.BL/Models/AdminDtos.cs` | AdminUserDto + AdminUserEditDto records |
| `BanterBotSports.BL/Services/Interfaces/IAdminService.cs` | Interfaz completa |
| `BanterBotSports.BL/Services/AdminService.cs` | Implementación con validaciones y LockoutEnd pattern |
| `BanterBotSports.Web/Controllers/AdminController.cs` | `[Authorize(Roles="Admin")]`, 12 actions |
| `BanterBotSports.Web/Program.cs` | DI + `--seed-admin` provisioning + no-admin startup warning |
| `BanterBotSports.Web/Views/Shared/_Layout.cshtml` | Nav link Admin (desktop + mobile) |
| `BanterBotSports.Web/Views/Admin/` | 6 views: Index, Organizadores, EditOrganizador, Jugadores, EditJugador, Configuracion |
| `BanterBotSports.Tests/Unit/AdminServiceTests.cs` | 16 unit tests (TDD) |
| `BanterBotSports.Tests/Unit/AdminControllerTests.cs` | 18 unit tests (TDD) |

## Test Plan
- [x] 34 unit tests pasan (16 AdminService + 18 AdminController)
- [x] Strict TDD: tests escritos antes de la implementación
- [x] Verificado con sdd-verify: PASS WITH WARNINGS (warning es test pre-existente no relacionado)
- [x] Conventional commits en todos los cambios